### PR TITLE
docs: add reverse proxy setup guide (Apache, Nginx, Caddy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ docker run -d \
 
 On first access (`https://your-server:9443`), a setup wizard will guide you through setting a password and optionally registering a Passkey. Recovery codes are printed to the log on first run.
 
+> **Trusted HTTPS / PWA:** The dashboard uses a self-signed certificate by default. To get a trusted certificate (required for mobile PWA install), place a reverse proxy with Let's Encrypt in front of it. See the **[Reverse Proxy Setup Guide](docs/reverse-proxy.md)** for Apache, Nginx, and Caddy configurations.
+
 > **Note:** Password login works via IP address — no domain required. Passkeys require a valid domain name. Klever Extension login requires the browser extension and a linked wallet address.
 
 ### Dashboard CLI Flags
@@ -329,6 +331,7 @@ This creates a GitHub Release with pre-built binaries for all platforms and SHA2
 ## Documentation
 
 - **[Complete Guide / Tutorial](tutorial.md)** — Step-by-step walkthrough of every feature with screenshots
+- **[Reverse Proxy Setup](docs/reverse-proxy.md)** — HTTPS with Let's Encrypt via Apache, Nginx, or Caddy (required for PWA install on mobile)
 - **[Product Requirements Document](docs/PRD.md)** — Full specification with architecture, data models, API endpoints, workflows, and implementation phases
 
 ## License

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -1,0 +1,214 @@
+# Reverse Proxy Setup (HTTPS with Let's Encrypt)
+
+The dashboard uses a self-signed TLS certificate (from its internal CA for mTLS with agents). While this encrypts traffic, browsers will show a certificate warning and **PWA installation will be blocked** because service workers require a trusted certificate.
+
+To get a trusted HTTPS connection, place a reverse proxy in front of the dashboard that terminates TLS with a Let's Encrypt certificate.
+
+## Prerequisites
+
+- A domain or subdomain pointing to your server (A record or CNAME)
+- Port 80 and 443 open on your firewall
+- [Certbot](https://certbot.eff.org/) installed (for Let's Encrypt)
+
+## Docker: Bind to localhost only
+
+When using a reverse proxy, the dashboard should only be reachable through the proxy — not directly from the internet:
+
+```bash
+docker run -d \
+  -p 127.0.0.1:9443:9443 \
+  -v klever-data:/root/.klever-node-hub \
+  --name klever-node-hub \
+  ctjaeger/klever-node-hub:latest \
+  --domain your-domain.example.com
+```
+
+> **Important:** The `--domain` flag must match the domain you use in the reverse proxy config. It sets the WebAuthn Relying Party ID for Passkey authentication.
+
+If running the dashboard as a binary (not Docker), it already listens on `127.0.0.1:9443` by default when you use `--addr 127.0.0.1:9443`.
+
+---
+
+## Option 1: Apache
+
+### 1. Enable required modules
+
+```bash
+sudo a2enmod proxy proxy_http proxy_wstunnel ssl rewrite headers
+sudo systemctl restart apache2
+```
+
+### 2. Obtain a certificate
+
+```bash
+sudo certbot certonly --apache -d your-domain.example.com
+```
+
+### 3. Create the virtual host
+
+Create `/etc/apache2/sites-available/klever-node-hub.conf`:
+
+```apache
+<VirtualHost *:80>
+    ServerName your-domain.example.com
+    RewriteEngine On
+    RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName your-domain.example.com
+
+    SSLEngine on
+    SSLCertificateFile    /etc/letsencrypt/live/your-domain.example.com/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/your-domain.example.com/privkey.pem
+
+    # Proxy to dashboard (self-signed backend cert)
+    ProxyPreserveHost On
+    SSLProxyEngine On
+    SSLProxyVerify none
+    SSLProxyCheckPeerCN off
+    SSLProxyCheckPeerName off
+
+    # WebSocket support (required for live metrics and log streaming)
+    RewriteEngine On
+    RewriteCond %{HTTP:Upgrade} websocket [NC]
+    RewriteRule ^/(.*)$ wss://127.0.0.1:9443/$1 [P,L]
+
+    # All other requests
+    ProxyPass / https://127.0.0.1:9443/
+    ProxyPassReverse / https://127.0.0.1:9443/
+
+    RequestHeader set X-Forwarded-Proto "https"
+</VirtualHost>
+```
+
+### 4. Enable and activate
+
+```bash
+sudo a2ensite klever-node-hub.conf
+sudo apache2ctl configtest
+sudo systemctl reload apache2
+```
+
+---
+
+## Option 2: Nginx
+
+### 1. Obtain a certificate
+
+```bash
+sudo certbot certonly --nginx -d your-domain.example.com
+```
+
+### 2. Create the server block
+
+Create `/etc/nginx/sites-available/klever-node-hub`:
+
+```nginx
+# Redirect HTTP to HTTPS
+server {
+    listen 80;
+    server_name your-domain.example.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name your-domain.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/your-domain.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/your-domain.example.com/privkey.pem;
+
+    location / {
+        proxy_pass https://127.0.0.1:9443;
+        proxy_ssl_verify off;  # dashboard uses self-signed cert
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support (required for live metrics and log streaming)
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+
+### 3. Enable and activate
+
+```bash
+sudo ln -s /etc/nginx/sites-available/klever-node-hub /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+---
+
+## Option 3: Caddy (automatic Let's Encrypt)
+
+[Caddy](https://caddyserver.com/) automatically obtains and renews Let's Encrypt certificates with zero configuration.
+
+### Using Docker Compose
+
+```yaml
+services:
+  klever-node-hub:
+    image: ctjaeger/klever-node-hub:latest
+    command: --domain your-domain.example.com
+    volumes:
+      - klever-data:/root/.klever-node-hub
+
+  caddy:
+    image: caddy:latest
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - caddy-data:/data
+      - ./Caddyfile:/etc/caddy/Caddyfile
+    depends_on:
+      - klever-node-hub
+
+volumes:
+  klever-data:
+  caddy-data:
+```
+
+Create a `Caddyfile`:
+
+```
+your-domain.example.com {
+    reverse_proxy klever-node-hub:9443 {
+        transport http {
+            tls_insecure_skip_verify
+        }
+    }
+}
+```
+
+Start with:
+
+```bash
+docker compose up -d
+```
+
+---
+
+## Verifying the setup
+
+1. Open `https://your-domain.example.com` in a browser
+2. Confirm the padlock icon shows a valid certificate (not self-signed)
+3. On mobile, you should now see the **"Add to Home Screen"** or install prompt for the PWA
+4. Check that live metrics update in real-time (confirms WebSocket proxying works)
+
+## Certificate renewal
+
+Certbot sets up automatic renewal by default. Verify with:
+
+```bash
+sudo certbot renew --dry-run
+```
+
+For Caddy, renewal is fully automatic — no action needed.

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -8,7 +8,9 @@ To get a trusted HTTPS connection, place a reverse proxy in front of the dashboa
 
 - A domain or subdomain pointing to your server (A record or CNAME)
 - Port 80 and 443 open on your firewall
-- [Certbot](https://certbot.eff.org/) installed (for Let's Encrypt)
+- [Certbot](https://certbot.eff.org/) installed with the plugin for your web server:
+  - Apache: `sudo apt install certbot python3-certbot-apache`
+  - Nginx: `sudo apt install certbot python3-certbot-nginx`
 
 ## Docker: Bind to localhost only
 
@@ -69,16 +71,19 @@ Create `/etc/apache2/sites-available/klever-node-hub.conf`:
     SSLProxyCheckPeerCN off
     SSLProxyCheckPeerName off
 
+    # Forward client IP for rate limiting and lockout
+    RequestHeader set X-Forwarded-For "%{REMOTE_ADDR}s"
+    RequestHeader set X-Forwarded-Proto "https"
+
     # WebSocket support (required for live metrics and log streaming)
+    # mod_proxy_wstunnel handles the upgrade automatically
     RewriteEngine On
     RewriteCond %{HTTP:Upgrade} websocket [NC]
-    RewriteRule ^/(.*)$ wss://127.0.0.1:9443/$1 [P,L]
+    RewriteRule ^/(.*)$ https://127.0.0.1:9443/$1 [P,L]
 
     # All other requests
     ProxyPass / https://127.0.0.1:9443/
     ProxyPassReverse / https://127.0.0.1:9443/
-
-    RequestHeader set X-Forwarded-Proto "https"
 </VirtualHost>
 ```
 
@@ -88,6 +93,14 @@ Create `/etc/apache2/sites-available/klever-node-hub.conf`:
 sudo a2ensite klever-node-hub.conf
 sudo apache2ctl configtest
 sudo systemctl reload apache2
+```
+
+### 5. Certificate renewal
+
+Certbot sets up automatic renewal by default. Verify with:
+
+```bash
+sudo certbot renew --dry-run
 ```
 
 ---
@@ -113,11 +126,12 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;
     server_name your-domain.example.com;
 
     ssl_certificate     /etc/letsencrypt/live/your-domain.example.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/your-domain.example.com/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
 
     location / {
         proxy_pass https://127.0.0.1:9443;
@@ -132,6 +146,10 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
+
+        # Keep WebSocket connections alive (default 60s kills idle connections)
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
     }
 }
 ```
@@ -144,11 +162,19 @@ sudo nginx -t
 sudo systemctl reload nginx
 ```
 
+### 4. Certificate renewal
+
+Certbot sets up automatic renewal by default. Verify with:
+
+```bash
+sudo certbot renew --dry-run
+```
+
 ---
 
 ## Option 3: Caddy (automatic Let's Encrypt)
 
-[Caddy](https://caddyserver.com/) automatically obtains and renews Let's Encrypt certificates with zero configuration.
+[Caddy](https://caddyserver.com/) automatically obtains and renews Let's Encrypt certificates — no certbot or manual renewal needed.
 
 ### Using Docker Compose
 
@@ -202,13 +228,3 @@ docker compose up -d
 2. Confirm the padlock icon shows a valid certificate (not self-signed)
 3. On mobile, you should now see the **"Add to Home Screen"** or install prompt for the PWA
 4. Check that live metrics update in real-time (confirms WebSocket proxying works)
-
-## Certificate renewal
-
-Certbot sets up automatic renewal by default. Verify with:
-
-```bash
-sudo certbot renew --dry-run
-```
-
-For Caddy, renewal is fully automatic — no action needed.

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -43,7 +43,7 @@ docker run -d \
 
 > **Important:** The `--domain` flag must match the domain you use in the reverse proxy config. It sets the WebAuthn Relying Party ID for Passkey authentication.
 
-If running the dashboard as a binary (not Docker), it already listens on `127.0.0.1:9443` by default when you use `--addr 127.0.0.1:9443`.
+If running the dashboard as a binary (not Docker), pass `--addr 127.0.0.1:9443` so it only listens on localhost behind the proxy.
 
 If you have **remote agents**, replace `127.0.0.1` with a LAN or public address that those agents can reach (and firewall-restrict it to agent source IPs). Browsers still go through the proxy on 443.
 
@@ -79,6 +79,7 @@ Create `/etc/apache2/sites-available/klever-node-hub.conf`:
     ServerName your-domain.example.com
 
     SSLEngine on
+    SSLProtocol -all +TLSv1.2 +TLSv1.3
     SSLCertificateFile    /etc/letsencrypt/live/your-domain.example.com/fullchain.pem
     SSLCertificateKeyFile /etc/letsencrypt/live/your-domain.example.com/privkey.pem
 
@@ -89,8 +90,8 @@ Create `/etc/apache2/sites-available/klever-node-hub.conf`:
     SSLProxyCheckPeerCN off
     SSLProxyCheckPeerName off
 
-    # Forward client IP for rate limiting and lockout
-    RequestHeader set X-Forwarded-For "%{REMOTE_ADDR}s"
+    # Forward client protocol. mod_proxy_http adds X-Forwarded-For
+    # automatically, which the dashboard uses for rate limiting and lockout.
     RequestHeader set X-Forwarded-Proto "https"
 
     # WebSocket support (required for live metrics and log streaming)

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -4,6 +4,8 @@ The dashboard uses a self-signed TLS certificate (from its internal CA for mTLS 
 
 To get a trusted HTTPS connection, place a reverse proxy in front of the dashboard that terminates TLS with a Let's Encrypt certificate.
 
+> **Run the reverse proxy on a standalone host.** Don't co-locate it with validator nodes or an agent. Ports 80/443, the mTLS pass-through to the dashboard, and the agent's direct connection to port 9443 collide too easily on a shared host.
+
 ## Prerequisites
 
 - A domain or subdomain pointing to your server (A record or CNAME)
@@ -12,9 +14,23 @@ To get a trusted HTTPS connection, place a reverse proxy in front of the dashboa
   - Apache: `sudo apt install certbot python3-certbot-apache`
   - Nginx: `sudo apt install certbot python3-certbot-nginx`
 
-## Docker: Bind to localhost only
+## Agents connect directly to port 9443
 
-When using a reverse proxy, the dashboard should only be reachable through the proxy — not directly from the internet:
+Agents authenticate to the dashboard with **mTLS client certificates** on the `/ws/agent` endpoint. A reverse proxy terminates TLS and strips those client certificates, so **agents must connect directly to port 9443 — not through the proxy**.
+
+```
+Browsers ──HTTPS:443─▶ Reverse Proxy ──HTTPS:9443─▶ Dashboard
+Agents   ──mTLS:9443────────────────────────────────▶ Dashboard
+```
+
+This has two consequences for how you expose the dashboard:
+
+- **Port 9443 must be reachable by every agent.** If any agent runs on a different host than the dashboard, that agent needs network reach to port 9443.
+- **The `127.0.0.1:9443` Docker binding shown below only works if every agent runs on the same host as the dashboard.** For remote agents, bind 9443 to a LAN address (e.g. `-p 10.0.0.5:9443:9443`) or the public interface — restricted to agent IPs via firewall — instead of `127.0.0.1`.
+
+## Docker: Bind to localhost only (all agents local)
+
+If the dashboard and **all** agents run on the same host, bind 9443 to `127.0.0.1` so it is only reachable through the proxy from the outside:
 
 ```bash
 docker run -d \
@@ -28,6 +44,8 @@ docker run -d \
 > **Important:** The `--domain` flag must match the domain you use in the reverse proxy config. It sets the WebAuthn Relying Party ID for Passkey authentication.
 
 If running the dashboard as a binary (not Docker), it already listens on `127.0.0.1:9443` by default when you use `--addr 127.0.0.1:9443`.
+
+If you have **remote agents**, replace `127.0.0.1` with a LAN or public address that those agents can reach (and firewall-restrict it to agent source IPs). Browsers still go through the proxy on 443.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `docs/reverse-proxy.md` with step-by-step instructions for placing a reverse proxy with Let's Encrypt in front of the dashboard
- Covers **Apache**, **Nginx**, and **Caddy** configurations including WebSocket proxying
- Adds a note in the README Installation section and a link in the Documentation section

## Motivation
The dashboard uses a self-signed certificate (from its internal CA for mTLS). Browsers block PWA/service worker installation on self-signed certs, so users need a trusted certificate via a reverse proxy to install the PWA on mobile.

## Test plan
- [ ] Verify all three proxy configs work with a fresh dashboard container
- [ ] Confirm PWA install prompt appears on mobile after setup
- [ ] Verify WebSocket connections work through the proxy (live metrics/logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)