### PR TITLE
ui: compact mobile stat cards & dark scrollbar

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -137,27 +137,27 @@ h1, h2, h3, h4, h5, h6 {
    ========================================================================== */
 
 ::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+    width: 5px;
+    height: 5px;
 }
 
 ::-webkit-scrollbar-track {
-    background: rgba(255, 255, 255, 0.03);
+    background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.2);
-    border-radius: 3px;
+    background: rgba(123, 146, 191, 0.18);
+    border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.35);
+    background: rgba(123, 146, 191, 0.35);
 }
 
 /* Firefox */
 * {
     scrollbar-width: thin;
-    scrollbar-color: rgba(255, 255, 255, 0.2) rgba(255, 255, 255, 0.03);
+    scrollbar-color: rgba(123, 146, 191, 0.18) transparent;
 }
 
 /* ==========================================================================
@@ -1270,8 +1270,8 @@ h1, h2, h3, h4, h5, h6 {
 
 .stats-grid {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: 16px;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
     margin-bottom: 16px;
 }
 
@@ -1293,10 +1293,10 @@ h1, h2, h3, h4, h5, h6 {
 .stat-card-header {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 10px 14px;
+    gap: 6px;
+    padding: 7px 10px;
     border-bottom: 1px solid rgba(123, 146, 191, 0.12);
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 700;
     letter-spacing: 0.06em;
     text-transform: uppercase;
@@ -1304,37 +1304,37 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .stat-card-header svg {
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     flex-shrink: 0;
     opacity: 0.7;
 }
 
 .stat-card-body {
-    padding: 16px 14px 14px;
+    padding: 10px 10px 8px;
 }
 
 .stat-card-label {
-    font-size: 10px;
+    font-size: 9px;
     font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--text-muted);
-    margin-bottom: 4px;
+    margin-bottom: 2px;
 }
 
 .stat-card-value {
-    font-size: 24px;
+    font-size: 20px;
     font-weight: 800;
     font-family: 'JetBrains Mono', 'SF Mono', monospace;
     color: var(--text-heading);
-    line-height: 1.3;
+    line-height: 1.2;
 }
 
 .stat-card-sub {
-    font-size: 12px;
+    font-size: 11px;
     color: var(--text-muted);
-    margin-top: 4px;
+    margin-top: 2px;
 }
 
 .text-success { color: var(--success); }
@@ -3104,6 +3104,37 @@ textarea.form-input {
 
     .stats-grid {
         grid-template-columns: repeat(2, 1fr);
+        gap: 16px;
+    }
+
+    .stat-card-header {
+        gap: 8px;
+        padding: 10px 14px;
+        font-size: 11px;
+    }
+
+    .stat-card-header svg {
+        width: 16px;
+        height: 16px;
+    }
+
+    .stat-card-body {
+        padding: 16px 14px 14px;
+    }
+
+    .stat-card-label {
+        font-size: 10px;
+        margin-bottom: 4px;
+    }
+
+    .stat-card-value {
+        font-size: 24px;
+        line-height: 1.3;
+    }
+
+    .stat-card-sub {
+        font-size: 12px;
+        margin-top: 4px;
     }
 
     .metrics-grid {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -137,27 +137,27 @@ h1, h2, h3, h4, h5, h6 {
    ========================================================================== */
 
 ::-webkit-scrollbar {
-    width: 5px;
-    height: 5px;
+    width: 6px;
+    height: 6px;
 }
 
 ::-webkit-scrollbar-track {
-    background: transparent;
+    background: rgba(255, 255, 255, 0.03);
 }
 
 ::-webkit-scrollbar-thumb {
-    background: rgba(123, 146, 191, 0.18);
-    border-radius: 4px;
+    background: rgba(123, 146, 191, 0.25);
+    border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: rgba(123, 146, 191, 0.35);
+    background: rgba(123, 146, 191, 0.4);
 }
 
 /* Firefox */
 * {
     scrollbar-width: thin;
-    scrollbar-color: rgba(123, 146, 191, 0.18) transparent;
+    scrollbar-color: rgba(123, 146, 191, 0.25) rgba(255, 255, 255, 0.03);
 }
 
 /* ==========================================================================
@@ -1270,8 +1270,8 @@ h1, h2, h3, h4, h5, h6 {
 
 .stats-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 10px;
+    grid-template-columns: 1fr;
+    gap: 16px;
     margin-bottom: 16px;
 }
 
@@ -1293,10 +1293,10 @@ h1, h2, h3, h4, h5, h6 {
 .stat-card-header {
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 7px 10px;
+    gap: 8px;
+    padding: 10px 14px;
     border-bottom: 1px solid rgba(123, 146, 191, 0.12);
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.06em;
     text-transform: uppercase;
@@ -1304,37 +1304,37 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .stat-card-header svg {
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
     flex-shrink: 0;
     opacity: 0.7;
 }
 
 .stat-card-body {
-    padding: 10px 10px 8px;
+    padding: 16px 14px 14px;
 }
 
 .stat-card-label {
-    font-size: 9px;
+    font-size: 10px;
     font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--text-muted);
-    margin-bottom: 2px;
+    margin-bottom: 4px;
 }
 
 .stat-card-value {
-    font-size: 20px;
+    font-size: 24px;
     font-weight: 800;
     font-family: 'JetBrains Mono', 'SF Mono', monospace;
     color: var(--text-heading);
-    line-height: 1.2;
+    line-height: 1.3;
 }
 
 .stat-card-sub {
-    font-size: 11px;
+    font-size: 12px;
     color: var(--text-muted);
-    margin-top: 2px;
+    margin-top: 4px;
 }
 
 .text-success { color: var(--success); }
@@ -3074,6 +3074,20 @@ textarea.form-input {
 }
 
 /* ==========================================================================
+   Responsive: Mobile compact stat cards
+   ========================================================================== */
+
+@media (max-width: 767px) {
+    .stats-grid { grid-template-columns: repeat(2, 1fr); gap: 10px; }
+    .stat-card-header { font-size: 10px; padding: 7px 10px; gap: 6px; }
+    .stat-card-header svg { width: 14px; height: 14px; }
+    .stat-card-body { padding: 10px 10px 8px; }
+    .stat-card-label { font-size: 9.5px; }
+    .stat-card-value { font-size: 20px; }
+    .stat-card-sub { font-size: 11px; }
+}
+
+/* ==========================================================================
    Responsive: Tablet / Desktop (768px+)
    ========================================================================== */
 
@@ -3104,37 +3118,6 @@ textarea.form-input {
 
     .stats-grid {
         grid-template-columns: repeat(2, 1fr);
-        gap: 16px;
-    }
-
-    .stat-card-header {
-        gap: 8px;
-        padding: 10px 14px;
-        font-size: 11px;
-    }
-
-    .stat-card-header svg {
-        width: 16px;
-        height: 16px;
-    }
-
-    .stat-card-body {
-        padding: 16px 14px 14px;
-    }
-
-    .stat-card-label {
-        font-size: 10px;
-        margin-bottom: 4px;
-    }
-
-    .stat-card-value {
-        font-size: 24px;
-        line-height: 1.3;
-    }
-
-    .stat-card-sub {
-        font-size: 12px;
-        margin-top: 4px;
     }
 
     .metrics-grid {


### PR DESCRIPTION
## Summary
- **Stat cards**: 2x2 grid on mobile instead of single column — halves the vertical space used by the summary section
- **Scrollbar**: uses theme-matching blue-grey tones with transparent track instead of bright white, blending into the dark theme
- Desktop/tablet layout unchanged — full sizing restored at 768px+

## Screenshots
**Before:** 4 full-width cards stacked vertically, bright scrollbar  
**After:** Compact 2x2 grid, near-invisible scrollbar matching dark theme

## Test plan
- [ ] Verify 2x2 layout on mobile viewport (<768px)
- [ ] Verify cards restore to full size on tablet (768px+) and 4-column on desktop (1200px+)
- [ ] Confirm scrollbar is subtle on both mobile and desktop
- [ ] Check PWA standalone mode on Android/iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)