### PR TITLE
fix: persist Flat/Grouped node view toggle

### DIFF
--- a/web/templates/overview.html
+++ b/web/templates/overview.html
@@ -713,10 +713,16 @@
             renderNodes();
         }
 
-        var nodeViewMode = 'flat';
+        var nodeViewMode = localStorage.getItem('nodeViewMode') || 'flat';
+        // Sync toggle buttons with persisted state
+        if (nodeViewMode === 'grouped') {
+            document.getElementById('view-flat-btn').classList.remove('active');
+            document.getElementById('view-grouped-btn').classList.add('active');
+        }
 
         function setNodeView(mode) {
             nodeViewMode = mode;
+            localStorage.setItem('nodeViewMode', mode);
             document.getElementById('view-flat-btn').classList.toggle('active', mode === 'flat');
             document.getElementById('view-grouped-btn').classList.toggle('active', mode === 'grouped');
             renderNodes();


### PR DESCRIPTION
## Summary
- The Provisioned Nodes "Flat/Grouped" view toggle was resetting to "Flat" on every page navigation
- Now persists the preference via `localStorage`, matching the pattern used by other UI preferences (e.g. DataTable page sizes)
- Restores button active state on page load to reflect the saved preference

## Test plan
- [ ] Select "Grouped" view, navigate away from the dashboard, then return — should still be "Grouped"
- [ ] Select "Flat" view, refresh the page — should remain "Flat"
- [ ] Clear localStorage and verify default is "Flat"

🤖 Generated with [Claude Code](https://claude.com/claude-code)