### PR TITLE
fix: show masked credentials when editing notification channels

### DIFF
--- a/internal/dashboard/handlers/notifications.go
+++ b/internal/dashboard/handlers/notifications.go
@@ -5,11 +5,19 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/CTJaeger/KleverNodeHub/internal/notify"
 	"github.com/CTJaeger/KleverNodeHub/internal/store"
 )
+
+// sensitiveKeys lists config keys whose values should be masked in API responses.
+var sensitiveKeys = map[string]bool{
+	"bot_token": true,
+	"app_token": true,
+	"user_key":  true,
+}
 
 // NotificationHandler handles notification configuration API requests.
 type NotificationHandler struct {
@@ -40,6 +48,7 @@ func (h *NotificationHandler) HandleListChannels(w http.ResponseWriter, _ *http.
 	type channelDetail struct {
 		Name   string               `json:"name"`
 		Type   string               `json:"type"`
+		Config map[string]string    `json:"config"`
 		Filter notify.ChannelFilter `json:"filter"`
 	}
 
@@ -48,6 +57,7 @@ func (h *NotificationHandler) HandleListChannels(w http.ResponseWriter, _ *http.
 		details[i] = channelDetail{
 			Name:   ch.Name,
 			Type:   h.getChannelType(ch.Name),
+			Config: h.getMaskedConfig(ch.Name),
 			Filter: ch.Filter,
 		}
 	}
@@ -106,6 +116,18 @@ func (h *NotificationHandler) HandleUpdateChannel(w http.ResponseWriter, r *http
 		h.updateSavedFilter(name, req.Filter)
 		writeJSON(w, http.StatusOK, map[string]any{"success": true})
 		return
+	}
+
+	// Merge masked values back with stored originals so users don't have
+	// to re-enter credentials they didn't change.
+	if saved := h.getSavedConfig(name); saved != nil {
+		for k, v := range req.Config {
+			if isMaskedValue(v) {
+				if orig, ok := saved[k]; ok {
+					req.Config[k] = orig
+				}
+			}
+		}
 	}
 
 	h.manager.RemoveChannel(name)
@@ -271,6 +293,42 @@ func (h *NotificationHandler) getChannelType(name string) string {
 		return ""
 	}
 	return req.Type
+}
+
+// getSavedConfig returns the stored config for a channel.
+func (h *NotificationHandler) getSavedConfig(name string) map[string]string {
+	key := "notify_ch_" + name
+	data, err := h.settings.Get(key)
+	if err != nil || data == "" {
+		return nil
+	}
+	var req channelConfigRequest
+	if err := json.Unmarshal([]byte(data), &req); err != nil {
+		return nil
+	}
+	return req.Config
+}
+
+// getMaskedConfig returns config with sensitive values partially masked.
+func (h *NotificationHandler) getMaskedConfig(name string) map[string]string {
+	cfg := h.getSavedConfig(name)
+	if cfg == nil {
+		return nil
+	}
+	masked := make(map[string]string, len(cfg))
+	for k, v := range cfg {
+		if sensitiveKeys[k] && len(v) > 4 {
+			masked[k] = v[:4] + strings.Repeat("•", len(v)-4)
+		} else {
+			masked[k] = v
+		}
+	}
+	return masked
+}
+
+// isMaskedValue returns true if the value looks like a masked placeholder.
+func isMaskedValue(v string) bool {
+	return strings.Contains(v, "••••")
 }
 
 // LoadSavedChannels loads previously saved notification channels from settings.

--- a/web/templates/overview.html
+++ b/web/templates/overview.html
@@ -713,10 +713,16 @@
             renderNodes();
         }
 
-        var nodeViewMode = 'flat';
+        var nodeViewMode = localStorage.getItem('nodeViewMode') || 'flat';
+        // Sync toggle buttons with persisted state
+        if (nodeViewMode === 'grouped') {
+            document.getElementById('view-flat-btn').classList.remove('active');
+            document.getElementById('view-grouped-btn').classList.add('active');
+        }
 
         function setNodeView(mode) {
             nodeViewMode = mode;
+            localStorage.setItem('nodeViewMode', mode);
             document.getElementById('view-flat-btn').classList.toggle('active', mode === 'flat');
             document.getElementById('view-grouped-btn').classList.toggle('active', mode === 'grouped');
             renderNodes();

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -437,6 +437,13 @@
             document.getElementById('ch-name').disabled = true;
             document.getElementById('ch-type').value = ch.type || 'telegram';
             updateChannelFields();
+            // Pre-fill config fields with stored (possibly masked) values
+            if (ch.config) {
+                document.querySelectorAll('.ch-config').forEach(el => {
+                    const val = ch.config[el.dataset.key];
+                    if (val) el.value = val;
+                });
+            }
             // Set severity checkboxes
             document.querySelectorAll('.ch-sev').forEach(c => {
                 c.checked = (ch.filter.severities || []).includes(c.value);


### PR DESCRIPTION
## Summary

When editing a notification channel (Telegram, Pushover, Webhook), the credential fields (Bot Token, Chat ID, etc.) appeared completely blank — even though values were stored and working. This gave users the false impression that their settings were lost, leading them to unnecessarily re-enter credentials every time they wanted to adjust filters or other settings.

**Changes:**
- The channel list API now returns config data with sensitive values partially masked (e.g. `1234••••••••` for bot tokens) while non-sensitive fields like `chat_id` and webhook `url` are shown in full
- The edit form pre-fills all config fields with the returned values (masked or plain)
- On save, the backend detects masked values (containing `••••`) and transparently merges them back with the stored originals — credentials are only overwritten when the user actually provides new ones
- Sensitive keys: `bot_token`, `app_token`, `user_key`

## Test plan
- [ ] Edit an existing Telegram channel — Bot Token should show as `1234••••••`, Chat ID in full
- [ ] Save without changing masked fields — verify credentials remain intact (send a test notification)
- [ ] Replace a masked Bot Token with a new value — verify the new token is saved and works
- [ ] Edit Pushover and Webhook channels — same masked behavior for their sensitive fields
- [ ] Add a new channel — fields should still be blank (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)