### PR TITLE
feat: surface Docker self-update in dashboard UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### 2026-05-14
+- **Docker Self-Update im Dashboard sichtbar**: Update-Banner zeigt jetzt auch im Docker-Betrieb den "Update Now"-Button, sofern `/var/run/docker.sock` gemountet ist — der Backend-Flow existierte bereits seit 2026-03-25, war im UI aber unkonditional ausgeblendet. Ohne Socket-Mount weiterhin der `docker pull`-Hinweis (jetzt mit Zusatz, wie One-Click-Updates aktiviert werden). Confirm-Dialog und Reload-Delay (15s statt 3s) für Docker-Mode angepasst, weil Image-Pull + Container-Recreate länger dauert als Binary-Restart. `GET /api/system/version` liefert dafür neues Feld `docker_self_update_available`. README-Docker-Run-Beispiel ergänzt um Socket-Mount + Sicherheitshinweis (Root-equivalent control).
+
 ### 2026-04-01
 - **Server Hardware Benchmark**: Neuer "Benchmark"-Tab auf der Server-Detailseite. Startet den offiziellen Klever Benchmark-Tool in einem Docker-Container. Testet Disk I/O, Network, CPU, Memory, KV Store mit PASS/WARN/FAIL. Ergebnis als farbcodierte Cards.
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,13 @@ Or use Docker:
 docker run -d \
   -p 9443:9443 \
   -v klever-data:/root/.klever-node-hub \
+  -v /var/run/docker.sock:/var/run/docker.sock \
   --name klever-node-hub \
   ctjaeger/klever-node-hub:latest \
   --domain your-server.example.com
 ```
+
+> **One-click updates:** Mounting `/var/run/docker.sock` lets the dashboard pull a new image and recreate its own container when you click **Update Now** in the update banner. Leave the mount off if you'd rather update manually with `docker pull` + `docker run` — the dashboard will then just show the `docker pull` command instead of the button. The socket grants root-equivalent control of the Docker daemon, so only mount it if you trust the dashboard accordingly.
 
 On first access (`https://your-server:9443`), a setup wizard will guide you through setting a password and optionally registering a Passkey. Recovery codes are printed to the log on first run.
 

--- a/internal/dashboard/handlers/system.go
+++ b/internal/dashboard/handlers/system.go
@@ -30,6 +30,7 @@ func NewSystemHandler(vc *dashboard.VersionChecker) *SystemHandler {
 // GET /api/system/version
 func (h *SystemHandler) HandleVersionInfo(w http.ResponseWriter, _ *http.Request) {
 	info := version.Get()
+	inDocker := isRunningInDocker()
 	result := map[string]any{
 		"version":    info.Version,
 		"git_commit": info.GitCommit,
@@ -38,7 +39,12 @@ func (h *SystemHandler) HandleVersionInfo(w http.ResponseWriter, _ *http.Request
 		"os":         info.OS,
 		"arch":       info.Arch,
 		"uptime":     version.Uptime().String(),
-		"is_docker":  isRunningInDocker(),
+		"is_docker":  inDocker,
+	}
+	// Only meaningful inside Docker — true when /var/run/docker.sock is mounted,
+	// which lets the dashboard pull a new image and recreate its own container.
+	if inDocker {
+		result["docker_self_update_available"] = dockerSelfUpdateAvailable()
 	}
 
 	latest := h.versionChecker.Latest()

--- a/web/templates/overview.html
+++ b/web/templates/overview.html
@@ -2166,12 +2166,19 @@
                     } else {
                         document.getElementById('update-link').style.display = 'none';
                     }
-                    if (data.is_docker) {
-                        // Docker: show pull command, hide update button
-                        document.getElementById('update-btn').style.display = 'none';
-                        const hint = document.getElementById('update-docker-hint');
-                        hint.textContent = 'docker pull ctjaeger/klever-node-hub:' + data.latest_version;
+                    const btn = document.getElementById('update-btn');
+                    const hint = document.getElementById('update-docker-hint');
+                    btn.dataset.dockerMode = data.is_docker ? '1' : '';
+                    if (data.is_docker && !data.docker_self_update_available) {
+                        // Docker without socket mount: show pull hint, hide update button
+                        btn.style.display = 'none';
+                        hint.textContent = 'docker pull ctjaeger/klever-node-hub:' + data.latest_version
+                            + '  (mount /var/run/docker.sock to enable one-click updates)';
                         hint.classList.remove('hidden');
+                    } else {
+                        // Binary, or Docker with socket mount: show update button
+                        btn.style.display = '';
+                        hint.classList.add('hidden');
                     }
                     if (!sessionStorage.getItem('update-dismissed-' + data.latest_version)) {
                         banner.classList.remove('hidden');
@@ -2187,16 +2194,21 @@
         }
 
         async function selfUpdate() {
-            if (!confirm('This will download and install the latest version. The dashboard will restart. Continue?')) return;
             const btn = document.getElementById('update-btn');
+            const dockerMode = btn.dataset.dockerMode === '1';
+            const msg = dockerMode
+                ? 'This will pull the new Docker image and recreate this container. The dashboard will be unavailable for a few seconds. Continue?'
+                : 'This will download and install the latest version. The dashboard will restart. Continue?';
+            if (!confirm(msg)) return;
             btn.disabled = true;
             btn.textContent = 'Updating...';
             try {
                 const resp = await API.post('/api/system/update');
                 const data = await resp.json();
                 if (data.success) {
-                    btn.textContent = 'Restarting...';
-                    setTimeout(() => location.reload(), 3000);
+                    btn.textContent = dockerMode ? 'Pulling image...' : 'Restarting...';
+                    // Docker pull + recreate is slower than a binary restart.
+                    setTimeout(() => location.reload(), dockerMode ? 15000 : 3000);
                 } else {
                     alert('Update failed: ' + (data.message || data.error));
                     btn.disabled = false;


### PR DESCRIPTION
## Summary

The Docker self-update flow (pull image + recreate container with rollback) has been in the backend since 2026-03-25 (`internal/dashboard/handlers/docker_selfupdate.go` + `system.go:78-95`) but was **unconditionally hidden in the UI** for any Docker install — the banner only ever showed a `docker pull` hint. This PR surfaces the existing **Update Now** button whenever the dashboard runs in Docker AND `/var/run/docker.sock` is mounted into the container.

- **Backend**: `GET /api/system/version` now returns `docker_self_update_available` (only set when running in Docker). True when the Docker socket is reachable.
- **UI**: Update banner branches on that flag instead of `is_docker` alone. Without the socket mount, the existing `docker pull` hint is kept and annotated with how to enable one-click updates.
- **UX polish**: confirm dialog is Docker-aware ("pull the new Docker image and recreate this container" vs binary restart). Reload delay bumped to 15s for Docker mode since image pull + container recreate is slower than a binary restart.
- **README**: the recommended `docker run` example now mounts `/var/run/docker.sock` with a short note explaining the security tradeoff (root-equivalent control of the Docker daemon — users can opt out by leaving the mount off and update manually).

No backend logic change. The existing rollback-on-failure flow (rename old container → create new → start new → stop/remove old) is untouched.

## Test plan

- [ ] **Binary install**: banner still shows the Update button; confirm dialog still says "download and install the latest version"
- [ ] **Docker install without socket mount**: banner shows the `docker pull ...` hint with the "mount /var/run/docker.sock to enable one-click updates" suffix; no Update button
- [ ] **Docker install with socket mount**: banner shows the Update button; confirm dialog says "pull the new Docker image and recreate this container"; clicking it pulls the new image, recreates the container with the same config, and the dashboard reloads after ~15s
- [ ] **Docker rollback path**: if the new container fails to start, the old container is renamed back and the dashboard keeps running (existing behavior, regression check)
- [ ] **Cross-build**: `GOOS=windows go build ./...` still succeeds (Windows stub in `docker_selfupdate_windows.go` is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)