### PR TITLE
feat: add Restart Agent action to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### 2026-05-14
+- **Restart Agent vom Dashboard**: Neuer Menü-Eintrag "Restart Agent" im Server-Actions-Dropdown (`···`-Button) auf der Overview-Seite. Schickt einen `agent.restart`-Command über die bestehende WebSocket-Verbindung; Agent acknowledged, dann re-exec'd via `syscall.Exec` (Unix) / `exec.Command`+exit (Windows). Systemd `Restart=always` (bzw. Docker-Restart-Policy) bringt den Prozess wieder hoch und die WebSocket reconnected automatisch. Nutzt denselben `restartAgent()`-Pfad wie der erprobte Auto-Restart nach `agent.update`. Laufende Klever-Nodes sind nicht betroffen — nur der Agent-Prozess wird neu gestartet. Neuer Endpoint `POST /api/agent/restart/{server_id}`, Whitelist um `agent.restart` erweitert.
+
 ### 2026-04-01
 - **Server Hardware Benchmark**: Neuer "Benchmark"-Tab auf der Server-Detailseite. Startet den offiziellen Klever Benchmark-Tool in einem Docker-Container. Testet Disk I/O, Network, CPU, Memory, KV Store mit PASS/WARN/FAIL. Ergebnis als farbcodierte Cards.
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -300,8 +300,8 @@ func runAgentLoop(ctx context.Context, wsURL string, ag *agent.Agent, executor *
 					default:
 					}
 				}
-				// Self-restart after successful agent update
-				if m.Action == "agent.update" && result.Success {
+				// Self-restart after a successful agent update or an explicit restart command.
+				if (m.Action == "agent.update" || m.Action == "agent.restart") && result.Success {
 					time.Sleep(500 * time.Millisecond) // let response be sent
 					restartAgent()
 				}

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -330,6 +330,7 @@ func main() {
 	mux.Handle("GET /api/agent/version", authMw(http.HandlerFunc(updateHandler.HandleLatestVersion)))
 	mux.Handle("POST /api/agent/update/{server_id}", authMw(http.HandlerFunc(updateHandler.HandleUpdateAgent)))
 	mux.Handle("POST /api/agent/update/all", authMw(http.HandlerFunc(updateHandler.HandleUpdateAll)))
+	mux.Handle("POST /api/agent/restart/{server_id}", authMw(http.HandlerFunc(updateHandler.HandleRestartAgent)))
 	mux.Handle("GET /api/agent/releases", authMw(http.HandlerFunc(updateHandler.HandleGitHubReleases)))
 	mux.Handle("POST /api/agent/download-release", authMw(http.HandlerFunc(updateHandler.HandleDownloadFromRelease)))
 	mux.Handle("POST /api/agent/download-release-auto", authMw(http.HandlerFunc(updateHandler.HandleDownloadReleaseAuto)))

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -137,6 +137,10 @@ func (e *Executor) Execute(msg *models.Message) *models.CommandResult {
 		err = e.executeKeyBackups(msg.Payload, result)
 	case "agent.update":
 		err = e.executeAgentUpdate(msg.Payload, result)
+	case "agent.restart":
+		// Nothing to do here — the main loop re-execs the agent after this
+		// returns a successful result. We just need to ack.
+		result.Output = "restarting"
 	case "server.benchmark":
 		err = e.executeBenchmark(ctx, result)
 	case "node.discovery":

--- a/internal/agent/whitelist.go
+++ b/internal/agent/whitelist.go
@@ -35,6 +35,7 @@ var AllowedCommands = map[string]CommandSpec{
 	"key.backup":             {Description: "Backup the validator key", RequiresContainer: false},
 	"key.backups":            {Description: "List validator key backups", RequiresContainer: false},
 	"agent.update":           {Description: "Update agent binary", RequiresContainer: false},
+	"agent.restart":          {Description: "Restart the agent process", RequiresContainer: false},
 	"server.benchmark":       {Description: "Run server hardware benchmark", RequiresContainer: false},
 }
 

--- a/internal/agent/whitelist_test.go
+++ b/internal/agent/whitelist_test.go
@@ -13,6 +13,7 @@ func TestValidateCommand_Allowed(t *testing.T) {
 		{"node.stop", "klever-backup"},
 		{"node.restart", "my_node.v2"},
 		{"node.status", "node-1"},
+		{"agent.restart", ""},
 	}
 
 	for _, tt := range tests {

--- a/internal/dashboard/handlers/update.go
+++ b/internal/dashboard/handlers/update.go
@@ -175,6 +175,47 @@ func (h *UpdateHandler) HandleUpdateAgent(w http.ResponseWriter, r *http.Request
 	})
 }
 
+// HandleRestartAgent handles POST /api/agent/restart/{server_id}
+// Sends a restart command to the agent over WebSocket. The agent acknowledges
+// the command and then re-execs itself; systemd (or Docker --restart) brings
+// it back up and the WebSocket reconnects on its own.
+func (h *UpdateHandler) HandleRestartAgent(w http.ResponseWriter, r *http.Request) {
+	serverID := r.PathValue("server_id")
+	if serverID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "server_id required"})
+		return
+	}
+
+	if !h.hub.IsConnected(serverID) {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "agent is not connected"})
+		return
+	}
+
+	msg := &models.Message{
+		ID:        fmt.Sprintf("restart-%d", time.Now().UnixNano()),
+		Type:      "command",
+		Action:    "agent.restart",
+		Timestamp: time.Now().Unix(),
+	}
+
+	// Short timeout — the agent acks before re-execing, so we expect a quick reply.
+	result, err := h.hub.SendCommand(serverID, msg, 10*time.Second)
+	if err != nil {
+		writeJSON(w, http.StatusGatewayTimeout, map[string]string{"error": fmt.Sprintf("restart failed: %v", err)})
+		return
+	}
+
+	if result.Error != "" {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": result.Error})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success": true,
+		"message": "agent restarting",
+	})
+}
+
 // HandleUpdateAll handles POST /api/agent/update/all
 // Sequentially updates all connected agents.
 // Optional body: { "version": "v0.3.4" } to send a specific version.

--- a/internal/dashboard/handlers/update.go
+++ b/internal/dashboard/handlers/update.go
@@ -206,6 +206,15 @@ func (h *UpdateHandler) HandleRestartAgent(w http.ResponseWriter, r *http.Reques
 	}
 
 	if result.Error != "" {
+		// An agent predating this feature rejects agent.restart at the
+		// command whitelist. Translate that into a clear "update the agent"
+		// message instead of leaking the raw validation error.
+		if strings.Contains(result.Error, "command not allowed") {
+			writeJSON(w, http.StatusConflict, map[string]string{
+				"error": "this agent version does not support restart — update the agent first",
+			})
+			return
+		}
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": result.Error})
 		return
 	}

--- a/web/templates/overview.html
+++ b/web/templates/overview.html
@@ -1176,7 +1176,6 @@
             } catch (e) {
                 showToast('Restart error: ' + (e.message || e), 'error');
             }
-            return false;
         }
 
         function deleteNodeFromMenu(event, id, name) {

--- a/web/templates/overview.html
+++ b/web/templates/overview.html
@@ -536,6 +536,7 @@
                             '<button class="actions-menu-btn" aria-label="Server actions" onclick="toggleServerActions(event, \'' + serverIDJS + '\')">...</button>' +
                             '<div class="actions-dropdown" id="server-actions-' + esc(server.id) + '">' +
                                 '<button class="actions-dropdown-item" onclick="openDetailsFromMenu(event, \'' + serverURLJS + '\')">Details</button>' +
+                                '<button class="actions-dropdown-item" onclick="restartAgentFromMenu(event, \'' + serverIDJS + '\', \'' + serverNameJS + '\')">Restart Agent</button>' +
                                 '<button class="actions-dropdown-item danger" onclick="deleteServerFromMenu(event, \'' + serverIDJS + '\', \'' + serverNameJS + '\')">Delete server</button>' +
                             '</div>' +
                         '</div>' +
@@ -1148,6 +1149,33 @@
             event.stopPropagation();
             closeServerActions();
             deleteServer(id, name);
+            return false;
+        }
+
+        async function restartAgentFromMenu(event, id, name) {
+            event.preventDefault();
+            event.stopPropagation();
+            closeServerActions();
+            var ok = await showConfirm(
+                'Restart Agent',
+                'Restart the agent on <strong>' + esc(name) + '</strong>?<br><br>The agent will reconnect within a few seconds. Running nodes are not affected.',
+                'Restart',
+                'btn-primary'
+            );
+            if (!ok) return;
+            showToast('Restarting agent on "' + name + '"...', 'info');
+            try {
+                var resp = await API.post('/api/agent/restart/' + id);
+                if (!resp) return; // auth refresh failed → API redirected to /login
+                var data = await resp.json();
+                if (resp.ok && data.success) {
+                    showToast('Agent on "' + name + '" is restarting.', 'success');
+                } else {
+                    showToast('Restart failed: ' + (data.error || data.message || 'unknown error'), 'error');
+                }
+            } catch (e) {
+                showToast('Restart error: ' + (e.message || e), 'error');
+            }
             return false;
         }
 


### PR DESCRIPTION
## Summary

The agents page lets you update agents but has no way to restart one — if an agent gets into a bad state, recovery requires SSH'ing into the server and running `systemctl restart klever-agent`. This PR adds a **Restart Agent** menu item in the server row's action dropdown on the overview page.

- **New endpoint**: `POST /api/agent/restart/{server_id}` (`internal/dashboard/handlers/update.go`). Returns 409 if the agent isn't connected, 504 on timeout, 200 with `{success: true, message: \"agent restarting\"}` otherwise.
- **Command**: sends `{type: \"command\", action: \"agent.restart\"}` over the existing WebSocket with a 10s timeout. The agent acknowledges, then the existing post-execution restart trigger in `cmd/agent/main.go` re-execs the process (extended from `m.Action == \"agent.update\"` to also fire on `\"agent.restart\"`). Same `restartAgent()` syscall the proven update flow uses.
- **Whitelist**: `agent.restart` added to `internal/agent/whitelist.go` so the command isn't rejected as unknown.
- **UI**: new `Restart Agent` entry in the server actions dropdown (between Details and Delete server), with a `showConfirm` dialog and toast feedback. Mirrors the existing patterns in `restartNodeFromMenu` / `deleteServerFromMenu`.

Running Klever node containers are **not** affected — only the agent process is restarted. Systemd's `Restart=always` (or Docker's restart policy) brings the agent back up and the WebSocket reconnects automatically.

## Test plan

- [ ] **Happy path**: agent online → menu → Restart Agent → confirm → \"is restarting\" toast → status briefly flips to offline → reconnects within ~5s → online
- [ ] **Offline agent**: menu → Restart Agent → \"Restart failed: agent is not connected\" toast
- [ ] **Klever nodes unaffected**: with a running Klever node container, restart the agent and verify the container keeps running (no impact on validator uptime)
- [ ] **Whitelist enforcement**: unrelated case — sending a bogus action still rejected (regression check via existing `TestValidateCommand_Rejected`)
- [ ] **Cross-build**: `GOOS=windows go build ./...` succeeds (handled by existing `cmd/agent/restart_windows.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)