### PR TITLE
fix(agent): eliminate two data races in executor and log streams

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -271,8 +271,10 @@ func runAgentLoop(ctx context.Context, wsURL string, ag *agent.Agent, executor *
 		}
 
 		if msg.Type == "command" {
-			// Set progress callback for this command — sends events to dashboard
-			executor.OnProgress = func(action string, payload map[string]any) {
+			// Per-command progress callback — sends events to dashboard.
+			// Defined per-command (not as an Executor field) so concurrent
+			// commands can't race when assigning the callback.
+			onProgress := func(action string, payload map[string]any) {
 				progressMsg := &models.Message{
 					ID:        fmt.Sprintf("progress-%d", time.Now().UnixNano()),
 					Type:      "event",
@@ -287,7 +289,7 @@ func runAgentLoop(ctx context.Context, wsURL string, ag *agent.Agent, executor *
 			}
 			// Execute command asynchronously
 			go func(m models.Message) {
-				result := executor.Execute(&m)
+				result := executor.Execute(&m, onProgress)
 				resultMsg := agent.BuildResultMessage(result)
 				select {
 				case resultCh <- resultMsg:

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -27,8 +27,7 @@ type ProgressFunc func(action string, payload map[string]any)
 
 // Executor handles incoming commands from the dashboard.
 type Executor struct {
-	docker     *DockerClient
-	OnProgress ProgressFunc
+	docker *DockerClient
 }
 
 // NewExecutor creates a new command executor.
@@ -44,7 +43,11 @@ func NewExecutorWithClient(client *DockerClient) *Executor {
 }
 
 // Execute processes a command message and returns a result.
-func (e *Executor) Execute(msg *models.Message) *models.CommandResult {
+//
+// onProgress is per-call rather than an Executor field so that concurrent
+// command goroutines don't race when assigning a new callback — each
+// execution carries its own.
+func (e *Executor) Execute(msg *models.Message, onProgress ProgressFunc) *models.CommandResult {
 	result := &models.CommandResult{
 		CommandID: msg.ID,
 	}
@@ -142,7 +145,7 @@ func (e *Executor) Execute(msg *models.Message) *models.CommandResult {
 		// returns a successful result. We just need to ack.
 		result.Output = "restarting"
 	case "server.benchmark":
-		err = e.executeBenchmark(ctx, result)
+		err = e.executeBenchmark(ctx, result, onProgress)
 	case "node.discovery":
 		nodes, discErr := e.docker.DiscoverNodes(ctx)
 		if discErr != nil {
@@ -625,16 +628,16 @@ func (e *Executor) executeConfigVersionRestore(payload any, result *models.Comma
 	return nil
 }
 
-func (e *Executor) executeBenchmark(ctx context.Context, result *models.CommandResult) error {
+func (e *Executor) executeBenchmark(ctx context.Context, result *models.CommandResult, onProgress ProgressFunc) error {
 	// Use a longer context for benchmark (up to 5 minutes)
 	benchCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	// Pass progress callback to stream status updates
 	var progressFn func(step, total int, status string)
-	if e.OnProgress != nil {
+	if onProgress != nil {
 		progressFn = func(step, total int, status string) {
-			e.OnProgress("benchmark.progress", map[string]any{
+			onProgress("benchmark.progress", map[string]any{
 				"step":   step,
 				"total":  total,
 				"status": status,

--- a/internal/agent/executor_test.go
+++ b/internal/agent/executor_test.go
@@ -76,7 +76,7 @@ func TestExecutor_Start(t *testing.T) {
 		},
 	}
 
-	result := exec.Execute(msg)
+	result := exec.Execute(msg, nil)
 	if !result.Success {
 		t.Errorf("expected success, got error: %s", result.Error)
 	}
@@ -99,7 +99,7 @@ func TestExecutor_Stop(t *testing.T) {
 		},
 	}
 
-	result := exec.Execute(msg)
+	result := exec.Execute(msg, nil)
 	if !result.Success {
 		t.Errorf("expected success, got error: %s", result.Error)
 	}
@@ -119,7 +119,7 @@ func TestExecutor_Restart(t *testing.T) {
 		},
 	}
 
-	result := exec.Execute(msg)
+	result := exec.Execute(msg, nil)
 	if !result.Success {
 		t.Errorf("expected success, got error: %s", result.Error)
 	}
@@ -139,7 +139,7 @@ func TestExecutor_Status(t *testing.T) {
 		},
 	}
 
-	result := exec.Execute(msg)
+	result := exec.Execute(msg, nil)
 	if !result.Success {
 		t.Errorf("expected success, got error: %s", result.Error)
 	}
@@ -162,7 +162,7 @@ func TestExecutor_RejectedCommand(t *testing.T) {
 		},
 	}
 
-	result := exec.Execute(msg)
+	result := exec.Execute(msg, nil)
 	if result.Success {
 		t.Error("expected failure for rejected command")
 	}
@@ -183,7 +183,7 @@ func TestExecutor_MissingContainerName(t *testing.T) {
 		// No payload
 	}
 
-	result := exec.Execute(msg)
+	result := exec.Execute(msg, nil)
 	if result.Success {
 		t.Error("expected failure for missing container name")
 	}

--- a/internal/agent/log_stream.go
+++ b/internal/agent/log_stream.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -233,8 +235,15 @@ func splitTimestamp(line string) (string, string) {
 }
 
 // LogStreamManager manages active log streams for containers.
+//
+// The streams map is touched from at least three goroutines (the caller of
+// StartStream/StopStream, the per-stream worker that removes itself when
+// the stream ends, and any caller of StopAll/ActiveStreams). All access
+// goes through mu — concurrent map writes panic at runtime, so the lock
+// is correctness, not optimization.
 type LogStreamManager struct {
 	docker  *DockerClient
+	mu      sync.Mutex
 	streams map[string]context.CancelFunc // containerName -> cancel
 }
 
@@ -249,15 +258,26 @@ func NewLogStreamManager(docker *DockerClient) *LogStreamManager {
 // StartStream starts streaming logs for a container.
 // Only one stream per container is allowed.
 func (m *LogStreamManager) StartStream(containerName string, onLine func(LogLine)) error {
-	// Stop existing stream for this container
+	// Stop existing stream for this container (acquires mu internally)
 	m.StopStream(containerName)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+
+	m.mu.Lock()
 	m.streams[containerName] = cancel
+	m.mu.Unlock()
 
 	go func() {
 		defer cancel()
-		defer delete(m.streams, containerName)
+		defer func() {
+			m.mu.Lock()
+			// Only remove if the entry is still ours — a concurrent
+			// StartStream may have replaced it with a newer cancel.
+			if existing, ok := m.streams[containerName]; ok && fnEq(existing, cancel) {
+				delete(m.streams, containerName)
+			}
+			m.mu.Unlock()
+		}()
 		_ = m.docker.StreamLogs(ctx, containerName, time.Now().Unix(), onLine)
 	}()
 
@@ -266,21 +286,44 @@ func (m *LogStreamManager) StartStream(containerName string, onLine func(LogLine
 
 // StopStream stops streaming logs for a container.
 func (m *LogStreamManager) StopStream(containerName string) {
-	if cancel, ok := m.streams[containerName]; ok {
-		cancel()
+	m.mu.Lock()
+	cancel, ok := m.streams[containerName]
+	if ok {
 		delete(m.streams, containerName)
+	}
+	m.mu.Unlock()
+
+	if ok {
+		cancel()
 	}
 }
 
 // StopAll stops all active log streams.
 func (m *LogStreamManager) StopAll() {
-	for name, cancel := range m.streams {
-		cancel()
-		delete(m.streams, name)
+	m.mu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(m.streams))
+	for _, c := range m.streams {
+		cancels = append(cancels, c)
+	}
+	m.streams = make(map[string]context.CancelFunc)
+	m.mu.Unlock()
+
+	// Cancel outside the lock — cancels can be slow if listeners block.
+	for _, c := range cancels {
+		c()
 	}
 }
 
 // ActiveStreams returns the number of active streams.
 func (m *LogStreamManager) ActiveStreams() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return len(m.streams)
+}
+
+// fnEq compares two CancelFunc values by their underlying pointer.
+// Used so the per-stream worker only deletes its own map entry if it
+// hasn't been replaced by a newer StartStream call.
+func fnEq(a, b context.CancelFunc) bool {
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
 }


### PR DESCRIPTION
## Summary

Two latent data races in the agent. Neither is caught by today's tests because the code paths aren't concurrent-stressed there, but both are real and the second one will panic the Go runtime when it triggers.

### 1) `executor.OnProgress` race
[cmd/agent/main.go:275](https://github.com/CTJaeger/KleverNodeHub/blob/main/cmd/agent/main.go#L275) assigned `executor.OnProgress` on every incoming command while a previous command's executor goroutine could still be calling it. Two near-simultaneous commands could see a half-written field, and the second would overwrite the first's callback mid-flight (e.g. benchmark.progress events sent to the wrong context).

**Fix**: make progress per-call. `Execute(msg, onProgress)` carries its own closure. The shared field on `Executor` is gone.

### 2) `LogStreamManager.streams` map race
[internal/agent/log_stream.go:236-286](https://github.com/CTJaeger/KleverNodeHub/blob/main/internal/agent/log_stream.go#L236-L286) — the streams map was written from at least three goroutines (`StartStream`, `StopStream`, the per-stream worker's `defer delete`) with no mutex. Concurrent map writes panic the Go runtime, so this is correctness, not perf.

**Fix**: `sync.Mutex` around all map access. The per-stream worker compares its own cancel func against the current map entry before deleting, so a `StartStream` that replaced an in-flight stream isn't wiped out by the old worker's cleanup. `StopAll` snapshots cancels under the lock and invokes them outside the lock.

## Test plan

- [x] `go vet`, `staticcheck`, `goimports -l` clean
- [x] `go build ./cmd/agent/...`
- [x] `go test -race -count=1 ./internal/agent/...` (all pass)
- [x] 6 existing executor tests updated to pass `nil` progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)