### PR TITLE
fix(agent): correctness fixes — tar traversal, port check, restart_container validation, public-IP refresh, restart drain

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -26,6 +27,16 @@ const (
 	nodeMetricsInterval = 15 * time.Second
 	reconnectBaseDelay  = 1 * time.Second
 	reconnectMaxDelay   = 60 * time.Second
+
+	// How often to re-detect the agent's public IP. The dashboard updates the
+	// stored IP from any heartbeat that carries a changed value, so this only
+	// affects how stale a recently-changed IP (DHCP renewal, VPN flap) can be.
+	publicIPRefreshInterval = 15 * time.Minute
+
+	// Maximum time to wait for queued result/progress messages to flush before
+	// restartAgent() exec's the new binary, so the dashboard sees the outcome
+	// of the agent.update / agent.restart command it just sent.
+	restartDrainTimeout = 3 * time.Second
 )
 
 func main() {
@@ -90,9 +101,21 @@ func main() {
 	}()
 
 	// --- Detect public IP ---
-	publicIP := agent.DetectPublicIP(ctx)
-	if publicIP != "" {
-		log.Printf("public IP: %s", publicIP)
+	// Stored in an atomic so the refresher goroutine and the per-connection
+	// goroutines below can update / read it without a mutex.
+	var publicIPAtomic atomic.Value
+	publicIPAtomic.Store(agent.DetectPublicIP(ctx))
+	if ip := publicIPAtomic.Load().(string); ip != "" {
+		log.Printf("public IP: %s", ip)
+	}
+
+	// Refresh the public IP periodically so a DHCP renewal or VPN flap
+	// surfaces in the next heartbeat rather than waiting for a restart.
+	go refreshPublicIP(ctx, &publicIPAtomic, publicIPRefreshInterval)
+
+	publicIPGetter := func() string {
+		v, _ := publicIPAtomic.Load().(string)
+		return v
 	}
 
 	// --- WebSocket connection loop with auto-reconnect ---
@@ -102,7 +125,7 @@ func main() {
 	for ctx.Err() == nil {
 
 		log.Printf("connecting to %s...", wsURL)
-		err := runAgentLoop(ctx, wsURL, ag, executor, metricsCollector, nodeMetrics, *dockerSocket, publicIP)
+		err := runAgentLoop(ctx, wsURL, ag, executor, metricsCollector, nodeMetrics, *dockerSocket, publicIPGetter)
 		if ctx.Err() != nil {
 			break
 		}
@@ -124,7 +147,11 @@ func main() {
 }
 
 // runAgentLoop connects to the dashboard and runs the message pump until disconnected.
-func runAgentLoop(ctx context.Context, wsURL string, ag *agent.Agent, executor *agent.Executor, metrics *agent.MetricsCollector, nodeMetrics *agent.NodeMetricsCollector, dockerSocket string, publicIP string) error {
+//
+// publicIPGetter is invoked when each outbound message is built so a public-IP
+// change during the lifetime of the connection is picked up on the next
+// heartbeat without needing to drop and reconnect.
+func runAgentLoop(ctx context.Context, wsURL string, ag *agent.Agent, executor *agent.Executor, metrics *agent.MetricsCollector, nodeMetrics *agent.NodeMetricsCollector, dockerSocket string, publicIPGetter func() string) error {
 	// Create a loop-scoped context so all goroutines (poller, sender) stop on disconnect
 	loopCtx, loopCancel := context.WithCancel(ctx)
 	defer loopCancel()
@@ -153,7 +180,7 @@ func runAgentLoop(ctx context.Context, wsURL string, ag *agent.Agent, executor *
 	log.Println("connected to dashboard")
 
 	// Send agent info on connect
-	infoMsg := ag.BuildInfoMessage(publicIP)
+	infoMsg := ag.BuildInfoMessage(publicIPGetter())
 	if err := writeMessage(loopCtx, conn, infoMsg); err != nil {
 		return fmt.Errorf("send agent info: %w", err)
 	}
@@ -207,7 +234,7 @@ func runAgentLoop(ctx context.Context, wsURL string, ag *agent.Agent, executor *
 					Payload: &models.HeartbeatPayload{
 						Timestamp: time.Now().Unix(),
 						Metrics:   metrics.Collect(),
-						PublicIP:  publicIP,
+						PublicIP:  publicIPGetter(),
 					},
 					Timestamp: time.Now().Unix(),
 				}
@@ -301,13 +328,59 @@ func runAgentLoop(ctx context.Context, wsURL string, ag *agent.Agent, executor *
 					}
 				}
 				// Self-restart after a successful agent update or an explicit restart command.
+				// Wait for the queued result (and any in-flight progress events) to
+				// actually leave the socket before exec'ing the new binary — otherwise
+				// the dashboard never sees the outcome of the command that triggered
+				// the restart.
 				if (m.Action == "agent.update" || m.Action == "agent.restart") && result.Success {
-					time.Sleep(500 * time.Millisecond) // let response be sent
+					drainBeforeRestart(resultCh, progressCh, restartDrainTimeout)
 					restartAgent()
 				}
 			}(msg)
 		}
 	}
+}
+
+// refreshPublicIP periodically re-detects the agent's public IP and updates
+// the supplied atomic. Logs only when the value actually changes, so a
+// stable network produces no noise.
+func refreshPublicIP(ctx context.Context, store *atomic.Value, every time.Duration) {
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ip := agent.DetectPublicIP(ctx)
+			if ip == "" {
+				continue
+			}
+			old, _ := store.Load().(string)
+			if ip != old {
+				log.Printf("public IP changed: %q -> %q", old, ip)
+				store.Store(ip)
+			}
+		}
+	}
+}
+
+// drainBeforeRestart waits for outbound result/progress queues to empty so the
+// final command result reaches the dashboard before exec replaces the agent.
+// Returns when the channels are empty (plus a small settle window for the
+// writer's in-flight conn.Write to flush) or after maxWait, whichever comes
+// first. len(chan)==0 only tells us nothing is queued; the settle covers the
+// writer being mid-iteration.
+func drainBeforeRestart(resultCh, progressCh chan *models.Message, maxWait time.Duration) {
+	deadline := time.Now().Add(maxWait)
+	for time.Now().Before(deadline) {
+		if len(resultCh) == 0 && len(progressCh) == 0 {
+			time.Sleep(200 * time.Millisecond)
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	log.Printf("restart: drain timed out after %s, executing anyway", maxWait)
 }
 
 // writeMessage serializes and sends a message over WebSocket.

--- a/internal/agent/docker_ops.go
+++ b/internal/agent/docker_ops.go
@@ -478,14 +478,18 @@ func (d *DockerClient) ListLocalImages(ctx context.Context) ([]string, error) {
 }
 
 // IsPortAvailable checks if a TCP port is available on the host.
+// "Available" here means nothing is currently accepting connections on it.
+//
+// The bounded dial timeout matters: a firewalled black-hole port (SYN
+// silently dropped, no RST) would block indefinitely without it, and
+// provisioning's FindAvailablePort calls this in a 100-port loop.
 func IsPortAvailable(port int) bool {
-	// Try to listen — if we can, the port is free
 	addr := fmt.Sprintf(":%d", port)
-	ln, err := (&net.Dialer{}).DialContext(context.Background(), "tcp", addr)
+	conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
 	if err != nil {
-		return true // Can't connect = port is free
+		return true // Can't connect (refused / timeout) = port is free
 	}
-	_ = ln.Close()
+	_ = conn.Close()
 	return false
 }
 

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -349,9 +349,19 @@ func (e *Executor) executeConfigWrite(payload any, result *models.CommandResult)
 
 	result.Output = "written: " + fileName
 
-	// Restart container if requested
+	// Restart container if requested.
+	//
+	// restart_container is a separate field from the command's container_name
+	// and was previously passed straight to docker.RestartContainer without
+	// going through ValidateCommand's regex check. Apply the same
+	// containerNamePattern here so the field can't smuggle an unsafe name
+	// past validation.
 	restartContainer := extractStringField(payload, "restart_container")
 	if restartContainer != "" {
+		if !containerNamePattern.MatchString(restartContainer) {
+			result.Output += " (restart skipped: invalid container name)"
+			return nil
+		}
 		ctx := context.Background()
 		if err := e.docker.RestartContainer(ctx, restartContainer, defaultStopTimeout); err != nil {
 			result.Output += " (restart failed: " + err.Error() + ")"

--- a/internal/agent/provisioner.go
+++ b/internal/agent/provisioner.go
@@ -316,12 +316,25 @@ func extractTarGz(r io.Reader, destDir string, stripComponents int) error {
 			continue
 		}
 
-		// Sanitize path to prevent directory traversal
+		// Sanitize path to prevent directory traversal.
+		// filepath.Clean alone is not sufficient — an entry named "/etc/passwd"
+		// would Clean to "etc/passwd" but Join into "destDir/etc/passwd",
+		// which is fine, while "../../../etc/passwd" cleans to
+		// "../../../etc/passwd" and the strings.Contains("..") check catches
+		// it but a sibling-of-dest path like "/foo" still escapes if destDir
+		// were "/bar". Use filepath.Rel against the absolute destDir to be
+		// certain the resolved target lives inside destDir.
 		name = filepath.Clean(name)
-		if strings.Contains(name, "..") {
+		target := filepath.Join(destDir, name)
+		absDest, errAbs := filepath.Abs(destDir)
+		absTarget, errTarget := filepath.Abs(target)
+		if errAbs != nil || errTarget != nil {
 			continue
 		}
-		target := filepath.Join(destDir, name)
+		rel, err := filepath.Rel(absDest, absTarget)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:


### PR DESCRIPTION
## Summary

Five small correctness fixes surfaced during the agent audit. Each is independently reviewable; grouped here because none warrants its own PR.

### 1) `extractTarGz` path-traversal hardening
`filepath.Clean` + `strings.Contains(name, "..")` was the only defense against traversal in downloaded config archives. Switch to a `filepath.Rel` check against the absolute destDir so any entry that resolves outside the destination is skipped.

### 2) `IsPortAvailable` bounded dial timeout
Previous `net.Dialer{}.DialContext(context.Background(), ...)` had no timeout. A firewalled black-hole port (SYN dropped, no RST) would block indefinitely — and `provisioner.FindAvailablePort` calls this in a loop of up to 100 ports. Use `net.DialTimeout(500ms)`.

### 3) Validate `restart_container` against the whitelist regex
`config.write` accepts an optional `restart_container` field that was passed straight to `docker.RestartContainer` without going through `ValidateCommand`'s regex. Apply `containerNamePattern` here too.

### 4) Periodic public-IP refresh
Agent detected its public IP once at startup. DHCP renewal / VPN flap meant the dashboard kept seeing a stale IP until restart. Store in `atomic.Value`, re-detect every 15 minutes, log only on change, read via getter so the heartbeat carries the latest value.

### 5) Replace blind 500ms sleep before exec with bounded queue drain
After `agent.update` / `agent.restart` success, the agent slept 500ms then exec'd, hoping the response had hit the socket. Replace with `drainBeforeRestart` which polls `len(resultCh)` and `len(progressCh)`, plus a small settle for the writer's in-flight write, capped by `restartDrainTimeout` (3s).

## Test plan

- [x] `go vet`, `staticcheck`, `goimports -l` clean
- [x] `go build ./cmd/agent/...`
- [x] `go test -race -count=1 ./internal/agent/...`
- [ ] On a node behind NAT, change the WAN address mid-session and confirm the next heartbeat reports the new IP (manual)
- [ ] Trigger `agent.restart` from the dashboard and confirm the result row appears in the audit log before the agent reconnects (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)