### PR TITLE
harden(agent): verify dashboard CA, restrict .pem in config.write, redact agent.info logs

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -52,7 +52,21 @@ func (a *Agent) Config() *Config {
 }
 
 // TLSConfig builds a tls.Config using the agent's mTLS credentials.
-// The returned config trusts the dashboard CA and presents the agent's client certificate.
+// The returned config trusts the dashboard CA and presents the agent's
+// client certificate, AND verifies the dashboard's server certificate
+// against the CA the agent stored at registration time.
+//
+// The CA we already load was previously ignored: InsecureSkipVerify was
+// set to true on the assumption that mTLS alone was sufficient. It is
+// not — mTLS only ensures the dashboard authenticates the agent, not
+// the reverse. Without verifying the dashboard's cert against the
+// stored CA, an attacker who has stolen any client cert can intercept
+// the connection.
+//
+// ServerName is pinned to "localhost" because crypto.DashboardTLSConfig
+// issues the dashboard's server certificate with DNSNames: ["localhost"]
+// regardless of the host/IP the agent dials. The cert is still signed
+// by the trusted CA, so verifying against that SAN proves authenticity.
 func (a *Agent) TLSConfig() (*tls.Config, error) {
 	if a.config == nil {
 		return nil, fmt.Errorf("agent not configured")
@@ -69,9 +83,10 @@ func (a *Agent) TLSConfig() (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		Certificates:       []tls.Certificate{cert},
-		RootCAs:            caCertPool,
-		InsecureSkipVerify: true, //nolint:gosec // dashboard uses self-signed cert; mTLS client auth is the real protection
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+		ServerName:   "localhost",
+		MinVersion:   tls.VersionTLS13,
 	}, nil
 }
 

--- a/internal/agent/config_ops.go
+++ b/internal/agent/config_ops.go
@@ -86,7 +86,7 @@ func WriteConfigFile(dataDir, fileName, content string) error {
 	if err := validateConfigPath(dataDir, filePath); err != nil {
 		return err
 	}
-	if err := validateConfigExtension(fileName); err != nil {
+	if err := validateWriteExtension(fileName); err != nil {
 		return err
 	}
 
@@ -222,11 +222,26 @@ func validateConfigPath(dataDir, targetPath string) error {
 	return nil
 }
 
-// validateConfigExtension checks if the file extension is allowed.
+// validateConfigExtension checks if the file extension is allowed for
+// read-side operations (config.list, config.read).
 func validateConfigExtension(fileName string) error {
 	ext := strings.ToLower(filepath.Ext(fileName))
 	if !allowedConfigExtensions[ext] {
 		return fmt.Errorf("file extension not allowed: %q", ext)
+	}
+	return nil
+}
+
+// validateWriteExtension is the stricter check applied to config.write.
+// Validator keys (.pem) are deliberately excluded — they must go through
+// key.import so key material rotation is an explicit, auditable action
+// rather than an ergonomic side-effect of a config edit.
+func validateWriteExtension(fileName string) error {
+	if err := validateConfigExtension(fileName); err != nil {
+		return err
+	}
+	if strings.ToLower(filepath.Ext(fileName)) == ".pem" {
+		return fmt.Errorf("writing .pem files via config.write is not allowed; use key.import for validator keys")
 	}
 	return nil
 }

--- a/internal/agent/config_ops_test.go
+++ b/internal/agent/config_ops_test.go
@@ -125,6 +125,32 @@ func TestWriteConfigFile_WithBackup(t *testing.T) {
 	}
 }
 
+func TestWriteConfigFile_RejectsPem(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// .pem must NOT be writable through config.write — validator keys go
+	// through key.import so rotations are explicit and auditable.
+	err := WriteConfigFile(dir, "validatorKey.pem", "-----BEGIN PRIVATE KEY-----\n")
+	if err == nil {
+		t.Fatal("expected WriteConfigFile to reject .pem, got nil")
+	}
+	if !strings.Contains(err.Error(), "key.import") {
+		t.Errorf("error message should point operator at key.import, got: %v", err)
+	}
+
+	// Reading .pem is still allowed (so the dashboard can render key info).
+	if err := os.WriteFile(filepath.Join(configDir, "validatorKey.pem"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadConfigFile(dir, "validatorKey.pem"); err != nil {
+		t.Errorf("expected ReadConfigFile(.pem) to succeed, got: %v", err)
+	}
+}
+
 func TestBackupConfigFile(t *testing.T) {
 	dir := t.TempDir()
 	configDir := filepath.Join(dir, "config")

--- a/internal/agent/tls_config_test.go
+++ b/internal/agent/tls_config_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CTJaeger/KleverNodeHub/internal/crypto"
+)
+
+// TestTLSConfig_VerifiesDashboardCert proves Agent.TLSConfig actually
+// verifies the dashboard's server cert against the stored CA — i.e. an
+// imposter dashboard not signed by that CA gets rejected, even when it
+// presents a valid-looking cert with the right SAN.
+func TestTLSConfig_VerifiesDashboardCert(t *testing.T) {
+	// Real CA + real dashboard, agent should connect.
+	caGood, err := crypto.NewCA()
+	if err != nil {
+		t.Fatalf("ca: %v", err)
+	}
+	serverCfg, err := crypto.DashboardTLSConfig(caGood)
+	if err != nil {
+		t.Fatalf("dashboard tls: %v", err)
+	}
+
+	agentPub, agentPriv, err := crypto.GenerateEd25519KeyPair()
+	if err != nil {
+		t.Fatalf("agent keys: %v", err)
+	}
+	agentCertPEM, err := caGood.IssueAgentCertificate(agentPub, "test-agent")
+	if err != nil {
+		t.Fatalf("issue agent cert: %v", err)
+	}
+	agentKeyPEM, err := crypto.EncodePrivateKeyPEM(agentPriv)
+	if err != nil {
+		t.Fatalf("encode agent key: %v", err)
+	}
+
+	addr := startMTLSEcho(t, serverCfg)
+
+	// Build the agent config from the same CA — should connect cleanly.
+	a := New(t.TempDir())
+	a.config = &Config{
+		ServerID:  "srv-1",
+		CertPEM:   string(agentCertPEM),
+		KeyPEM:    string(agentKeyPEM),
+		CACertPEM: string(caGood.CertPEM),
+	}
+	cfg, err := a.TLSConfig()
+	if err != nil {
+		t.Fatalf("agent TLSConfig: %v", err)
+	}
+
+	if err := dialAndGet(addr, cfg); err != nil {
+		t.Fatalf("expected handshake to succeed with trusted CA, got: %v", err)
+	}
+
+	// Now stand up a SECOND dashboard signed by a DIFFERENT CA, and try to
+	// connect with the ORIGINAL agent config — agent should reject.
+	caEvil, err := crypto.NewCA()
+	if err != nil {
+		t.Fatalf("evil ca: %v", err)
+	}
+	evilServerCfg, err := crypto.DashboardTLSConfig(caEvil)
+	if err != nil {
+		t.Fatalf("evil dashboard tls: %v", err)
+	}
+	evilAddr := startMTLSEcho(t, evilServerCfg)
+
+	// Even though evilServerCfg's cert has the right SAN ("localhost"),
+	// it's signed by a different CA. Verification must fail.
+	if err := dialAndGet(evilAddr, cfg); err == nil {
+		t.Fatal("expected handshake to FAIL against imposter CA, but it succeeded")
+	} else if !strings.Contains(err.Error(), "signed by unknown authority") &&
+		!strings.Contains(err.Error(), "unknown certificate authority") {
+		t.Logf("(got expected failure, message: %v)", err)
+	}
+}
+
+func startMTLSEcho(t *testing.T, cfg *tls.Config) string {
+	t.Helper()
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", cfg)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, "ok")
+		}),
+		ReadTimeout:  3 * time.Second,
+		WriteTimeout: 3 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return ln.Addr().String()
+}
+
+func dialAndGet(addr string, cfg *tls.Config) error {
+	d := &net.Dialer{Timeout: 3 * time.Second}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: cfg,
+			DialContext:     d.DialContext,
+		},
+		Timeout: 3 * time.Second,
+	}
+	resp, err := client.Get("https://" + addr + "/")
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+	return nil
+}

--- a/internal/dashboard/ws/agent_handler.go
+++ b/internal/dashboard/ws/agent_handler.go
@@ -126,7 +126,9 @@ func (h *AgentHandler) readLoop(ctx context.Context, conn *websocket.Conn, serve
 
 		switch msg.Action {
 		case "agent.info":
-			log.Printf("agent info from %s: %s", serverID, string(data))
+			// handleAgentInfo logs the individual fields (version, IP, region)
+			// it cares about. Dumping the raw message risks leaking any future
+			// field (config snapshot, cert, etc.) into logs as soon as it ships.
 			h.handleAgentInfo(ctx, serverID, &msg)
 
 		case "agent.heartbeat":


### PR DESCRIPTION
## Summary

Three independent hardening steps from the agent audit.

### 1) Verify the dashboard's server certificate
`internal/agent/agent.go` set `InsecureSkipVerify: true` on the steady-state mTLS connection. The CA cert pool was loaded and immediately discarded.

mTLS only proves the dashboard authenticated the agent — not the reverse. Anyone with a stolen client cert could impersonate the dashboard.

**Change**: drop `InsecureSkipVerify`, keep `RootCAs` populated, and pin `ServerName: "localhost"` because `crypto.DashboardTLSConfig` issues server certs with `DNSNames: ["localhost"]` regardless of the address the agent dials. The cert is still signed by the trusted CA, so verifying against that SAN proves authenticity.

New test `TestTLSConfig_VerifiesDashboardCert` exercises both halves:
- a dashboard signed by the trusted CA connects cleanly ✅
- an imposter dashboard signed by a different CA (with a perfectly valid server cert and the right SAN) is rejected ✅

### 2) Block `.pem` from `config.write`
`config.write` previously accepted any extension in `allowedConfigExtensions`, including `.pem`. A compromised dashboard could overwrite `validatorKey.pem` via `config.write` rather than the dedicated `key.import` path the audit log focuses on.

Add `validateWriteExtension` which excludes `.pem`. Reads still see `.pem` so the dashboard can render key info. Test: `TestWriteConfigFile_RejectsPem`.

### 3) Drop raw `agent.info` payload from dashboard logs
`internal/dashboard/ws/agent_handler.go` did `log.Printf("agent info from %s: %s", serverID, string(data))`. Today the payload is only `version/os/hostname/ip`, but any future field (config snapshot, cert thumbprint, debug data) would land in logs unredacted as soon as it shipped. `handleAgentInfo` already logs the specific fields it cares about — the raw dump is redundant.

> ⚠️ The most-impactful security finding from the audit — self-update authenticity — is intentionally **not** in this PR. It needs an offline signing key and a release-pipeline change, tracked in #54.

## Test plan

- [x] `go vet`, `staticcheck`, `goimports -l` clean
- [x] `go build ./...`
- [x] `go test -race -count=1 ./internal/agent/... ./internal/crypto/... ./internal/dashboard/ws/...`
- [x] New `TestTLSConfig_VerifiesDashboardCert` covers trusted + imposter dashboards
- [x] New `TestWriteConfigFile_RejectsPem` covers the write/read asymmetry
- [ ] Deploy to one node, verify the agent connects (i.e. the SAN pin works against the real dashboard cert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)