### PR TITLE
perf+obs(agent): parallel node polling, looser discovery cadence, poll-duration logs

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -21,8 +21,15 @@ import (
 )
 
 const (
-	heartbeatInterval   = 30 * time.Second
-	discoveryInterval   = 30 * time.Second
+	heartbeatInterval = 30 * time.Second
+
+	// Container discovery via the Docker API can take up to its own 30s
+	// context timeout per cycle. Running the cycle every 30s left zero idle
+	// time between cycles on a slow daemon — back-to-back discovery starved
+	// other writes. 60s keeps the dashboard's node list reasonably fresh
+	// without crowding the rest of the agent's outbound traffic.
+	discoveryInterval = 60 * time.Second
+
 	nodeMetricsInterval = 15 * time.Second
 	reconnectBaseDelay  = 1 * time.Second
 	reconnectMaxDelay   = 60 * time.Second

--- a/internal/agent/node_metrics.go
+++ b/internal/agent/node_metrics.go
@@ -120,7 +120,11 @@ func (c *NodeMetricsCollector) CollectOne(nodeID, serverID string) (*models.Node
 	return c.pollNode(nodeID, serverID, ep)
 }
 
-// CollectAll polls all registered nodes and returns metrics events plus any stall alerts.
+// CollectAll polls all registered nodes and returns metrics events plus any
+// stall alerts. Polling is parallel — a single unreachable node would
+// otherwise block the whole cycle for defaultNodePollTimeout. With N nodes
+// down, the previous serial loop took N * 5 s before the writer could send
+// any of the partial results.
 func (c *NodeMetricsCollector) CollectAll(serverID string) ([]*models.NodeMetricsEvent, []*models.NodeNonceStallEvent) {
 	c.mu.RLock()
 	snapshot := make(map[string]nodeEndpoint, len(c.nodes))
@@ -129,28 +133,49 @@ func (c *NodeMetricsCollector) CollectAll(serverID string) ([]*models.NodeMetric
 	}
 	c.mu.RUnlock()
 
-	var events []*models.NodeMetricsEvent
-	var stalls []*models.NodeNonceStallEvent
+	if len(snapshot) == 0 {
+		return nil, nil
+	}
+
+	var (
+		wg      sync.WaitGroup
+		sliceMu sync.Mutex
+		events  = make([]*models.NodeMetricsEvent, 0, len(snapshot))
+		stalls  = make([]*models.NodeNonceStallEvent, 0)
+	)
 
 	for nodeID, ep := range snapshot {
-		evt, err := c.pollNode(nodeID, serverID, ep)
-		if err != nil {
-			log.Printf("poll node %s: %v", nodeID, err)
-			events = append(events, &models.NodeMetricsEvent{
-				NodeID:      nodeID,
-				ServerID:    serverID,
-				Error:       err.Error(),
-				CollectedAt: time.Now().Unix(),
-			})
-			continue
-		}
-		events = append(events, evt)
+		wg.Add(1)
+		go func(nodeID string, ep nodeEndpoint) {
+			defer wg.Done()
 
-		// Check nonce stall
-		if stall := c.checkNonceStall(nodeID, serverID, evt); stall != nil {
-			stalls = append(stalls, stall)
-		}
+			evt, err := c.pollNode(nodeID, serverID, ep)
+			if err != nil {
+				log.Printf("poll node %s: %v", nodeID, err)
+				sliceMu.Lock()
+				events = append(events, &models.NodeMetricsEvent{
+					NodeID:      nodeID,
+					ServerID:    serverID,
+					Error:       err.Error(),
+					CollectedAt: time.Now().Unix(),
+				})
+				sliceMu.Unlock()
+				return
+			}
+
+			// checkNonceStall takes c.mu internally; safe to call from
+			// multiple goroutines.
+			stall := c.checkNonceStall(nodeID, serverID, evt)
+
+			sliceMu.Lock()
+			events = append(events, evt)
+			if stall != nil {
+				stalls = append(stalls, stall)
+			}
+			sliceMu.Unlock()
+		}(nodeID, ep)
 	}
+	wg.Wait()
 
 	return events, stalls
 }
@@ -277,8 +302,20 @@ func (c *NodeMetricsCollector) RunPoller(ctx context.Context, serverID string, m
 			c.mu.RLock()
 			n := len(c.nodes)
 			c.mu.RUnlock()
+			pollStart := time.Now()
 			events, stalls := c.CollectAll(serverID)
-			log.Printf("node metrics poll: %d nodes registered, %d events, %d stalls", n, len(events), len(stalls))
+			elapsed := time.Since(pollStart)
+			// With parallel polling a healthy cycle finishes in well under a
+			// second; anything past defaultNodePollTimeout means at least one
+			// node hit its 5s timeout. Surface that so operators don't need
+			// to packet-capture to see a flapping node.
+			if elapsed >= defaultNodePollTimeout {
+				log.Printf("node metrics poll: %d nodes, %d events, %d stalls in %s (slow — a node may be unreachable)",
+					n, len(events), len(stalls), elapsed.Round(time.Millisecond))
+			} else {
+				log.Printf("node metrics poll: %d nodes, %d events, %d stalls in %s",
+					n, len(events), len(stalls), elapsed.Round(time.Millisecond))
+			}
 
 			for _, evt := range events {
 				msg := &models.Message{

--- a/internal/agent/node_metrics_test.go
+++ b/internal/agent/node_metrics_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -309,6 +310,45 @@ func TestCollectAll_UnreachableNode(t *testing.T) {
 	}
 	if events[0].Error == "" {
 		t.Error("expected error in event for unreachable node")
+	}
+}
+
+// TestCollectAll_PollsInParallel proves polling isn't serialized. With N
+// slow nodes that each take ~slowDelay to respond, a serial implementation
+// would take N*slowDelay; the parallel implementation should be close to
+// slowDelay regardless of N.
+func TestCollectAll_PollsInParallel(t *testing.T) {
+	const slowDelay = 100 * time.Millisecond
+	const nodeCount = 5
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(slowDelay)
+		_, _ = w.Write([]byte(sampleNodeStatusJSON))
+	}))
+	defer srv.Close()
+	host, port := parseHostPort(t, srv.URL)
+
+	c := NewNodeMetricsCollector(WithHTTPClient(srv.Client()))
+	c.mu.Lock()
+	for i := 0; i < nodeCount; i++ {
+		c.nodes[fmt.Sprintf("node-%d", i)] = nodeEndpoint{host: host, port: port}
+	}
+	c.mu.Unlock()
+
+	start := time.Now()
+	events, _ := c.CollectAll("server-1")
+	elapsed := time.Since(start)
+
+	if len(events) != nodeCount {
+		t.Fatalf("events = %d, want %d", len(events), nodeCount)
+	}
+	// Generous upper bound — parallel should be ~slowDelay; serial would be
+	// nodeCount*slowDelay = 500ms. Anything past 3x slowDelay means we're
+	// effectively serial.
+	maxParallel := 3 * slowDelay
+	if elapsed > maxParallel {
+		t.Fatalf("CollectAll took %s for %d nodes at %s each — looks serial (limit %s)",
+			elapsed, nodeCount, slowDelay, maxParallel)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three small perf/observability fixes from the agent audit.

### 1) Parallelize per-node polling in `CollectAll`
The previous loop polled each node sequentially. With a 5s per-node HTTP timeout, one unreachable node blocked the whole cycle for 5s; N unreachable nodes blocked it for N×5s, and the writer goroutine that drains the output channels then has to catch up on a burst of buffered messages all at once.

Spawn one goroutine per node, gather results under a short-lived slices mutex, `WaitGroup`'d. `checkNonceStall` already locks `c.mu` internally so it stays correct under concurrent callers.

New `TestCollectAll_PollsInParallel` proves the cycle finishes within 3× the per-node delay regardless of node count — a serial implementation would fail with N≥3.

### 2) Log node-poll cycle duration, flag slow cycles
The existing `"node metrics poll: N nodes, X events, Y stalls"` log gave no sense of how long the cycle took. Add elapsed time and tag cycles ≥ `defaultNodePollTimeout` (5s) as slow, so a flapping node shows up without packet capture.

### 3) Bump `discoveryInterval` 30s → 60s
The previous 30s exactly matched the Docker context timeout used inside `RunDiscovery`. Under a busy Docker daemon, cycles ran back-to-back with zero idle time, crowding everything else sharing the agent's outbound channel. 60s keeps the dashboard's node list fresh enough while leaving real breathing room.

## Test plan

- [x] `go vet`, `staticcheck`, `goimports -l` clean
- [x] `go build ./cmd/agent/...`
- [x] `go test -race -count=1 ./internal/agent/...`
- [x] New `TestCollectAll_PollsInParallel` (5 nodes × 100ms slow handler, finishes < 300ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)