### PR TITLE
fix: SetMaxOpenConns(1) + evaluator hub-awareness — eliminate SQLITE_BUSY and false offline alerts

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -209,7 +209,7 @@ func main() {
 	// Note: we do NOT resolve all firing alerts on startup.
 	// The evaluator will naturally resolve them if conditions clear,
 	// and dedup prevents duplicate alerts from being created.
-	alertEvaluator := alerting.NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifyManager)
+	alertEvaluator := alerting.NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifyManager, hub.IsConnected)
 	alertEvaluator.EnsureDefaults()
 	alertEvaluator.Start()
 	regressionDetector := alerting.NewRegressionDetector(versionHistoryStore, metricsStore, nodeStore, alertStore, notifyManager)

--- a/internal/dashboard/alerting/evaluator.go
+++ b/internal/dashboard/alerting/evaluator.go
@@ -35,20 +35,24 @@ var systemMetrics = map[string]bool{
 
 // Evaluator evaluates alert rules against current metrics.
 type Evaluator struct {
-	mu            sync.Mutex
-	alertStore    *store.AlertStore
-	metricsStore  *store.MetricsStore
-	nodeStore     *store.NodeStore
-	serverStore   *store.ServerStore
-	settingsStore *store.SettingsStore
-	notifier      *notify.Manager
-	states        map[string]*AlertState
-	cancel        context.CancelFunc
-	interval      time.Duration
-	idCounter     int64
+	mu                 sync.Mutex
+	alertStore         *store.AlertStore
+	metricsStore       *store.MetricsStore
+	nodeStore          *store.NodeStore
+	serverStore        *store.ServerStore
+	settingsStore      *store.SettingsStore
+	notifier           *notify.Manager
+	states             map[string]*AlertState
+	cancel             context.CancelFunc
+	interval           time.Duration
+	idCounter          int64
+	isAgentConnected   func(serverID string) bool // nil = not available
 }
 
 // NewEvaluator creates a new alert evaluator.
+// isConnected (optional) reports whether an agent WebSocket is currently live;
+// when provided, Agent Offline alerts are suppressed for connected agents even if
+// the DB heartbeat is stale (e.g. writes were queued under DB contention).
 func NewEvaluator(
 	alertStore *store.AlertStore,
 	metricsStore *store.MetricsStore,
@@ -56,16 +60,18 @@ func NewEvaluator(
 	serverStore *store.ServerStore,
 	settingsStore *store.SettingsStore,
 	notifier *notify.Manager,
+	isConnected func(serverID string) bool,
 ) *Evaluator {
 	return &Evaluator{
-		alertStore:    alertStore,
-		metricsStore:  metricsStore,
-		nodeStore:     nodeStore,
-		serverStore:   serverStore,
-		settingsStore: settingsStore,
-		notifier:      notifier,
-		states:        make(map[string]*AlertState),
-		interval:      15 * time.Second,
+		alertStore:       alertStore,
+		metricsStore:     metricsStore,
+		nodeStore:        nodeStore,
+		serverStore:      serverStore,
+		settingsStore:    settingsStore,
+		notifier:         notifier,
+		states:           make(map[string]*AlertState),
+		interval:         15 * time.Second,
+		isAgentConnected: isConnected,
 	}
 }
 
@@ -337,6 +343,14 @@ func (e *Evaluator) evaluateHeartbeatRule(rule *store.AlertRule, servers []model
 		}
 
 		stateKey := fmt.Sprintf("%s:server:%s", rule.ID, srv.ID)
+
+		// If the agent WebSocket is live, suppress the offline alert even when the
+		// DB heartbeat looks stale (heartbeat DB writes can be queued/dropped under
+		// contention; in-memory hub state is the authoritative liveness source).
+		if e.isAgentConnected != nil && e.isAgentConnected(srv.ID) {
+			e.markNormal(stateKey, now)
+			continue
+		}
 
 		staleSec := float64(now.Unix() - srv.LastHeartbeat)
 		breached := staleSec > thresholdSec

--- a/internal/dashboard/alerting/evaluator.go
+++ b/internal/dashboard/alerting/evaluator.go
@@ -35,18 +35,18 @@ var systemMetrics = map[string]bool{
 
 // Evaluator evaluates alert rules against current metrics.
 type Evaluator struct {
-	mu                 sync.Mutex
-	alertStore         *store.AlertStore
-	metricsStore       *store.MetricsStore
-	nodeStore          *store.NodeStore
-	serverStore        *store.ServerStore
-	settingsStore      *store.SettingsStore
-	notifier           *notify.Manager
-	states             map[string]*AlertState
-	cancel             context.CancelFunc
-	interval           time.Duration
-	idCounter          int64
-	isAgentConnected   func(serverID string) bool // nil = not available
+	mu               sync.Mutex
+	alertStore       *store.AlertStore
+	metricsStore     *store.MetricsStore
+	nodeStore        *store.NodeStore
+	serverStore      *store.ServerStore
+	settingsStore    *store.SettingsStore
+	notifier         *notify.Manager
+	states           map[string]*AlertState
+	cancel           context.CancelFunc
+	interval         time.Duration
+	idCounter        int64
+	isAgentConnected func(serverID string) bool // nil = not available
 }
 
 // NewEvaluator creates a new alert evaluator.

--- a/internal/dashboard/alerting/evaluator_test.go
+++ b/internal/dashboard/alerting/evaluator_test.go
@@ -89,7 +89,7 @@ func TestEvaluatorEnsureDefaults(t *testing.T) {
 	defer cleanup()
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 
 	// First call should create defaults
 	eval.EnsureDefaults()
@@ -154,7 +154,7 @@ func TestEvaluatorThresholdAlert(t *testing.T) {
 	}
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 
 	// Run evaluation manually
 	eval.evaluate()
@@ -216,7 +216,7 @@ func TestEvaluatorResolvesAlert(t *testing.T) {
 	}
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 
 	// First eval: should fire
 	eval.evaluate()
@@ -280,7 +280,7 @@ func TestEvaluatorPendingThenFiring(t *testing.T) {
 	_ = alertStore.CreateRule(rule)
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 
 	eval.evaluate()
 
@@ -334,7 +334,7 @@ func TestEvaluatorSystemMetrics(t *testing.T) {
 	_ = alertStore.CreateRule(rule)
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 	eval.evaluate()
 
 	active, _ := alertStore.ListActiveAlerts()
@@ -369,7 +369,7 @@ func TestEvaluatorHeartbeatStale(t *testing.T) {
 	_ = alertStore.CreateRule(rule)
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 	eval.evaluate()
 
 	active, _ := alertStore.ListActiveAlerts()
@@ -430,7 +430,7 @@ func TestEvaluatorNodeOffline(t *testing.T) {
 	_ = alertStore.CreateRule(rule)
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 
 	eval.evaluate()
 
@@ -486,7 +486,7 @@ func TestEvaluatorNonceStall(t *testing.T) {
 	_ = alertStore.CreateRule(rule)
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 
 	eval.evaluate()
 
@@ -537,7 +537,7 @@ func TestEvaluatorNonceStall_NotYetStalled(t *testing.T) {
 	_ = alertStore.CreateRule(rule)
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 
 	eval.evaluate()
 
@@ -553,7 +553,7 @@ func TestEvaluatorStartStop(t *testing.T) {
 	defer cleanup()
 
 	notifier := notify.NewManager()
-	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier)
+	eval := NewEvaluator(alertStore, metricsStore, nodeStore, serverStore, settingsStore, notifier, nil)
 
 	eval.Start()
 	time.Sleep(100 * time.Millisecond)

--- a/internal/dashboard/scheduler/scheduler.go
+++ b/internal/dashboard/scheduler/scheduler.go
@@ -83,7 +83,15 @@ func (s *Scheduler) Stop() {
 }
 
 func (s *Scheduler) runDecimation(ctx context.Context) {
-	// Run once at startup to clean any backlog
+	// Delay the startup run so the server finishes initializing and starts
+	// listening before decimation takes the single DB connection for a while.
+	// With SetMaxOpenConns(1), chunked decimation interleaves with other ops
+	// between slices, so a large backlog won't hang startup — just slow it.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(10 * time.Second):
+	}
 	s.decimateOnce()
 
 	ticker := time.NewTicker(decimationInterval)

--- a/internal/dashboard/ws/agent_handler.go
+++ b/internal/dashboard/ws/agent_handler.go
@@ -135,6 +135,19 @@ func (h *AgentHandler) readLoop(ctx context.Context, conn *websocket.Conn, serve
 		}
 	}
 
+	// enqueueOrSpawn is like enqueueLossy but never drops: if the worker queue
+	// is full it falls back to a fire-and-forget goroutine. Used for heartbeat
+	// DB writes, which are infrequent (every 25 s) and critical — dropping them
+	// causes the alerting evaluator to see a stale timestamp and fire false
+	// Agent Offline alerts even while the agent is still connected.
+	enqueueOrSpawn := func(fn func()) {
+		select {
+		case work <- fn:
+		default:
+			go fn()
+		}
+	}
+
 	for {
 		_, data, err := conn.Read(ctx)
 		if err != nil {
@@ -162,8 +175,13 @@ func (h *AgentHandler) readLoop(ctx context.Context, conn *websocket.Conn, serve
 			h.handleAgentInfo(ctx, serverID, &msg)
 
 		case "agent.heartbeat":
-			enqueueLossy("agent.heartbeat", func() {
-				_ = h.serverStore.UpdateHeartbeat(serverID, recvAt)
+			// DB heartbeat write is non-lossy: dropping it leaves the DB timestamp
+			// stale, which triggers false Agent Offline alerts from the evaluator.
+			// Heartbeats arrive every 25s so spawning a goroutine on queue-full is safe.
+			recvAtCopy := recvAt
+			enqueueOrSpawn(func() { _ = h.serverStore.UpdateHeartbeat(serverID, recvAtCopy) })
+			// Metrics + IP derivation from heartbeat payload can be lossy.
+			enqueueLossy("agent.heartbeat metrics", func() {
 				h.handleHeartbeatMetrics(serverID, &m)
 				h.handleHeartbeatIP(ctx, serverID, &m)
 			})

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -41,17 +41,21 @@ func Open(dbPath string) (*DB, error) {
 		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
 
-	// Busy timeout: SQLite allows one writer at a time, and writes from different
-	// stores run on different pooled connections. Rather than serialize on a
-	// single connection (which also serializes reads and stalled startup while a
-	// large decimation backlog held the connection), keep the pool and wait out
-	// brief write contention. The decimation runs in short bucket-aligned slices
-	// and heartbeats persist off the WS loop, so contention windows are short and
-	// a generous timeout absorbs them instead of erroring with SQLITE_BUSY.
-	if _, err := sqlDB.Exec("PRAGMA busy_timeout=30000"); err != nil {
-		_ = sqlDB.Close()
-		return nil, fmt.Errorf("set busy timeout: %w", err)
-	}
+	// Serialize all DB access on a single connection. SQLite allows only one
+	// writer at a time; with multiple pooled connections, concurrent writes from
+	// different stores race for the write lock and get SQLITE_BUSY. A single
+	// connection lets database/sql queue writes in Go-land instead — no SQLite
+	// lock contention, no SQLITE_BUSY. Reads are also serialized, which is fine:
+	// our read load is negligible and WAL mode's reader/writer independence only
+	// matters with truly concurrent connections, which we don't use here.
+	//
+	// The previous PRAGMA busy_timeout approach was insufficient: the PRAGMA is
+	// per-connection and only applied to the one connection that executed it at
+	// Open() time; new pool connections got the default 0ms timeout and would
+	// immediately fail with SQLITE_BUSY under any write contention.
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	sqlDB.SetConnMaxLifetime(0)
 
 	store := &DB{db: sqlDB}
 


### PR DESCRIPTION
## Problem

Two related issues persisted after PR #63:

**1. SQLITE_BUSY every hour during decimation**

Confirmed in production logs:
```
2026/06/21 01:25:23 decimation error: aggregate: database is locked (5) (SQLITE_BUSY)
2026/06/21 02:25:02 decimation error: aggregate: database is locked (5) (SQLITE_BUSY)
2026/06/21 03:24:51 decimation error: aggregate: database is locked (5) (SQLITE_BUSY)
2026/06/21 04:40:43 decimation error: aggregate: database is locked (5) (SQLITE_BUSY)
```

The `PRAGMA busy_timeout=30000` we set in `Open()` is a **per-connection** setting. It applied only to the one connection that executed it; every subsequent connection created by `database/sql`'s pool got SQLite's default of **0 ms**. Under any write contention the new connections immediately errored with `SQLITE_BUSY` — the 30 s timeout was effectively never active.

**2. False "Agent Offline" alerts while agents are connected**

After fixing the pong-blocking in #63, agents stay connected in the hub's in-memory map. But the alerting evaluator reads `srv.LastHeartbeat` from the **database**, which can be stale when heartbeat DB writes were dropped by `enqueueLossy` under backpressure. So the evaluator fires "Agent Offline" even though the agent is alive and pinging.

## Fix

**`store/sqlite.go` — `SetMaxOpenConns(1)`**

Serialize all DB access on a single connection. `database/sql` queues operations in Go-land instead of racing at the SQLite level — no lock contention, no `SQLITE_BUSY` possible. Reads are also serialized, which is acceptable (our read load is negligible and WAL's concurrency benefit only matters with truly concurrent connections).

The previous revert of `SetMaxOpenConns(1)` was due to a startup hang: a large decimation backlog held the single connection before the server began listening. That hang no longer occurs because decimation is now chunked into short slices (each releases the connection between iterations). A 10 s startup delay is added as extra safety.

**`alerting/evaluator.go` — hub connection awareness**

`NewEvaluator` now accepts an optional `isConnected(serverID string) bool` callback (wired to `hub.IsConnected` in `main.go`, `nil` in tests). `evaluateHeartbeatRule` skips the offline alert and clears existing state for any server whose agent WebSocket is currently live. The DB heartbeat is only checked for agents that have actually disconnected.

**`ws/agent_handler.go` — non-lossy heartbeat DB write**

The `agent.heartbeat` case now separates `UpdateHeartbeat` from the metrics/IP writes. The DB write uses `enqueueOrSpawn`: queues on the worker but falls back to a goroutine rather than dropping. Heartbeats arrive every 25 s so occasional goroutine spawning is safe and bounded. Metrics/IP derivation remains lossy (unchanged from #63).

## Test plan

- [ ] Run full test suite: `go test ./... -race` — all pass
- [ ] Deploy to production and confirm no `SQLITE_BUSY` in `journalctl` during the next decimation run (top of the hour)
- [ ] Confirm "Agent Offline" alerts no longer fire while agents are connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)